### PR TITLE
Move configuration to YAML in standard home and /usr/local/share locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ If you are okay living dangerously and potentially being disappointed, you can i
 One of the more appealing features in ``gemini`` is that it automatically annotates variants in a VCF file with several
 genome annotations (see below for more details).  However, you must first install these data files on your system. 
 It's easy enough --- you just need to run the following script and tell it in which what full path you'd like to install
-the necessary data files.  
+the necessary data files. The recommended path is in ``/usr/local/share``:
 
-    gemini/install-data.py /path/to/gemini/data/
+    gemini/install-data.py /usr/local/share/gemini
 
 
 Overview

--- a/gemini/annotations.py
+++ b/gemini/annotations.py
@@ -4,15 +4,7 @@ import os
 import sys
 import collections
 
-# determine where the user installed the gemini annotation suite.
-gemini_installation_path = os.path.split(__file__)[0]
-gemini_config_file = os.path.join(gemini_installation_path, 'data/gemini.conf')
-gemini_conf = open(gemini_config_file, 'r')
-config_lines = gemini_conf.readlines()
-if len(config_lines) > 0:
-    anno_dirname = config_lines[0].rstrip()
-else:
-    sys.exit('Cannot determine where gemini annotation files are located.  Exiting.')
+from gemini.config import read_gemini_config
     
 # dictionary of anno_type -> open Tabix file handles
 annos = {}
@@ -25,7 +17,9 @@ def load_annos():
     
     dbsnp_handle = annotations.annos['dbsnp']
     hits = dbsnp_handle.fetch(chrom, start, end)
-    """    
+    """
+    config = read_gemini_config()
+    anno_dirname = config["annotation_dir"]
     anno_files   = {
                     'cytoband'  : os.path.join(anno_dirname, 'hg19.cytoband.bed.gz'),
                     'dbsnp'     : os.path.join(anno_dirname, 'dbsnp.135.vcf.gz'),

--- a/gemini/config.py
+++ b/gemini/config.py
@@ -1,0 +1,58 @@
+"""Configuration YAML files for Gemini.
+
+Provide Gemini configuration files in two alternative locations:
+
+- Global:    /usr/local/share/gemini/gemini-config.yaml
+- User only: $HOME/.gemini/gemini-config.yaml
+
+Prefer the former if you have system level permissions for installation
+since it will work for all system users.
+"""
+import os
+
+import yaml
+
+CONFIG_FILE = "gemini-config.yaml"
+CONFIG_DIRS = [os.path.join(os.environ["HOME"], ".gemini"),
+               "/usr/local/share/gemini"]
+
+def _get_config_file(dirs=None):
+    dnames = CONFIG_DIRS if dirs is None else dirs + CONFIG_DIRS
+    for dname in dnames:
+        fname = os.path.join(dname, CONFIG_FILE)
+        if os.path.exists(fname):
+            return fname
+    raise ValueError("Gemini configuration file {0} not found in {1}".format(
+            CONFIG_FILE, dnames))
+
+def read_gemini_config(dirs=None, allow_missing=False):
+    try:
+        fname = _get_config_file(dirs)
+    except ValueError:
+        if allow_missing:
+            return {}
+        else:
+            raise
+    with open(fname) as in_handle:
+        return yaml.load(in_handle)
+
+def _find_best_config_file(dirs=None):
+    dnames = CONFIG_DIRS if dirs is None else dirs + CONFIG_DIRS
+    dnames.reverse()
+    for dname in dnames:
+        if os.access(dname, os.W_OK) or os.access(os.path.dirname(dname), os.W_OK):
+            return os.path.join(dname, CONFIG_FILE)
+    raise ValueError("Gemini configuration: "
+                     "Could not find writeable directory: {0}".format(
+            dnames))
+
+def write_gemini_config(new_config, dirs=None):
+    try:
+        fname = _get_config_file(dirs)
+    except ValueError:
+        fname = _find_best_config_file(dirs)
+    if not os.path.exists(os.path.dirname(fname)):
+        os.makedirs(os.path.dirname(fname))
+    with open(fname, "w") as out_handle:
+        yaml.dump(new_config, out_handle, allow_unicode=False,
+                  default_flow_style=False)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
         version=version,
         #install_requires=['numpy>=1.6.0', 'pyparsing>=1.5.6', 'pysam>=0.6', 'pyvcf>=0.4.2'],
         # temp. until cyvcf is merged intop PyVcf
-        install_requires=['numpy>=1.6.0', 'pyparsing>=1.5.6', 'pysam>=0.6', 'cyvcf>=0.1.1'],
+        install_requires=['numpy>=1.6.0', 'pyparsing>=1.5.6', 'pysam>=0.6', 'cyvcf>=0.1.1',
+                          'PyYAML >= 3.10'],
         dependency_links = ['http://github.com/arq5x/cyvcf/tarball/master#egg=cyvcf-0.1.1'],
         requires = ['python (>=2.5, <3.0)'],
         packages=['gemini',


### PR DESCRIPTION
Aaron;
Here's a go at updating Gemini configuration to use a YAML config file in either /usr/local/share/gemini/gemini-config.yaml or $HOME/.gemini/gemini-config.yaml instead of the python site-libraries directory. The configuration code is flexible to allow adding other default directories to look in as well.
