### PR TITLE
Mappability annotations: GMS and GRC

### DIFF
--- a/gemini/annotation_provenance/make-ncbi-grc-patches.py
+++ b/gemini/annotation_provenance/make-ncbi-grc-patches.py
@@ -38,7 +38,7 @@ def grc_regions_from_url(url):
                 chrom = int(parts[5])
             except ValueError:
                 chrom = parts[5]
-            yield GrcRegion(chrom, int(parts[11]), int(parts[12]),
+            yield GrcRegion(chrom, int(parts[11]) - 1, int(parts[12]),
                             "grc_%s" % ("fix" if parts[2].endswith("PATCH") else "novel"))
         
 

--- a/gemini/database.py
+++ b/gemini/database.py
@@ -107,6 +107,10 @@ def create_tables(cursor):
                                                             aaf_1kg_afr float,                          \
                                                             aaf_1kg_eur float,                          \
                                                             aaf_1kg_all float,                          \
+                                                            grc text default NULL,                     \
+                                                            gms_illumina float,                          \
+                                                            gms_solid float,                          \
+                                                            gms_iontorrent float,                          \
                                                             PRIMARY KEY(variant_id ASC))''')
 
     cursor.execute('''create table if not exists variant_impacts  (variant_id integer,                         \
@@ -155,7 +159,7 @@ def insert_variation(cursor, buffer):
                                                      ?,?,?,?,?,?,?,?,?,?, \
                                                      ?,?,?,?,?,?,?,?,?,?, \
                                                      ?,?,?,?,?,?,?,?,?,?, \
-                                                     ?)', \
+                                                     ?,?,?,?,?)', \
                                                      buffer)
     cursor.execute("END")
     

--- a/gemini/gemini_load.py
+++ b/gemini/gemini_load.py
@@ -60,6 +60,8 @@ def prepare_variation(args, var, v_id):
     esp          = annotations.get_esp_info(var)
     thousandG    = annotations.get_1000G_info(var)
     recomb_rate  = annotations.get_recomb_info(var)
+    gms          = annotations.get_gms(var)
+    grc          = annotations.get_grc(var)
 
     # impact is a list of impacts for this variant
     impacts = None
@@ -148,7 +150,7 @@ def prepare_variation(args, var, v_id):
                infotag.get_frac_dels(var), infotag.get_haplotype_score(var), infotag.get_quality_by_depth(var),
                infotag.get_allele_count(var), infotag.get_allele_bal(var), esp.found, esp.aaf_EA, esp.aaf_AA,
                esp.aaf_ALL, esp.exome_chip, thousandG.found, thousandG.aaf_AMR, thousandG.aaf_ASN, thousandG.aaf_AFR, 
-               thousandG.aaf_EUR, thousandG.aaf_ALL]
+               thousandG.aaf_EUR, thousandG.aaf_ALL, grc, gms.illumina, gms.solid, gms.iontorrent]
     return variant, variant_impacts
     
 

--- a/gemini/install-data.py
+++ b/gemini/install-data.py
@@ -38,6 +38,8 @@ anno_files = \
 'ALL.wgs.phase1_release_v3.20101123.snps_indels_sv.sites.vcf.gz.tbi',
 'genetic_map_HapMapII_GRCh37.gz',
 'genetic_map_HapMapII_GRCh37.gz.tbi']
+# Annotation files for be merged into main repository
+tmp_anno_files = ['GRCh37-gms-mappability.vcf.gz', 'GRC_patch_regions.bed.gz']
 
 def install_annotation_files(anno_root_dir):
     """Download required annotation files.
@@ -59,6 +61,10 @@ def install_annotation_files(anno_root_dir):
     for dl in anno_files:
         url = "http://people.virginia.edu/~arq5x/files/gemini/annotations/{fname}".format(fname=dl)
         _download_to_dir(url, anno_dir)
+    for dl in tmp_anno_files:
+        for ext in ["", ".tbi"]:
+            url = "https://s3.amazonaws.com/chapmanb/gemini/{fname}{ext}".format(fname=dl, ext=ext)
+            _download_to_dir(url, anno_dir)
  
 def _download_to_dir(url, dirname):
     """


### PR DESCRIPTION
Aaron;
This adds annotations associated with mappability. The Genome Mappability Score (GMS) adds low GMS scores for Illumina, SOLiD and IonTorrent technologies derived from:

http://sourceforge.net/apps/mediawiki/gma-bio/index.php?title=Download_GMS#Download_GMS_by_Chromosome_and_Sequencing_Technology

This is generated by parsing the raw GMS inputs, filtering by GMS scores < 25.0 in any technology, and converting into a VCF input.

The GRC is a BED file of patched and fixed regions from the Genome Reference Consortium:

http://www.ncbi.nlm.nih.gov/projects/genome/assembly/grc/human/

The general notion is that variants falling into low mappability regions or GRC fix regions could be worth additional investigation for technology or genome specific errors.

Is there a good place to document the values and input file information?

Thanks for taking a look and let me know if you have any questions.
