### PR TITLE
Restrict pyparsing version dependency to Python 2.x compatible versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         name="gemini",
         version=version,
         install_requires=['numpy>=1.6.0', 
-                          'pyparsing>=1.5.6', 
+                          'pyparsing>=1.5.6,<=1.5.7', 
                           'pysam>=0.6',
                           'cyvcf>=0.1.5', 
                           'PyYAML >= 3.10', 


### PR DESCRIPTION
A tiny version fix for the pyparsing dependency. pyparsing 2.0.0 only works on Python 3 and  will be pulled in and fail during setup. This restricts the dependency to the Python 2 compatible versions.
