### PR TITLE
IPython loading speedups

### DIFF
--- a/docs/content/loading.rst
+++ b/docs/content/loading.rst
@@ -6,8 +6,8 @@ Loading a VCF file into Gemini
 ==============================
 Annotate with snpEff or VEP
 ==============================
-While not necessary, we suggest that you first annotate your VCF with snpEff or 
-VEP prior to loading it into Gemini.  Instructions for for installing and 
+While not necessary, we suggest that you first annotate your VCF with snpEff or
+VEP prior to loading it into Gemini.  Instructions for for installing and
 running these tools can be found in the following section:
 
 :doc:`functional_annotation`
@@ -16,13 +16,13 @@ running these tools can be found in the following section:
 The basics
 ==============================
 
-Before we can use Gemini to explore genetic variation, we must first ``load`` our 
-VCF file into the Gemini database framework.  We expect you to have first 
-annotated the functional consequence of each variant in your VCF using either 
-VEP or snpEff (Note that v3.0+ of snpEff is required to track the amino acid 
-length of each impacted transcript). Logically,the loading step is done with 
-the ``gemini load`` command.  Below are two examples based on a VCF file that 
-we creatively name my.vcf.  The first example assumes that the VCF has been 
+Before we can use Gemini to explore genetic variation, we must first ``load`` our
+VCF file into the Gemini database framework.  We expect you to have first
+annotated the functional consequence of each variant in your VCF using either
+VEP or snpEff (Note that v3.0+ of snpEff is required to track the amino acid
+length of each impacted transcript). Logically,the loading step is done with
+the ``gemini load`` command.  Below are two examples based on a VCF file that
+we creatively name my.vcf.  The first example assumes that the VCF has been
 pre-annotated with VEP and the second assumes snpEff.
 
 .. code-block:: bash
@@ -33,19 +33,19 @@ pre-annotated with VEP and the second assumes snpEff.
 	# snpEff-annotated VCF
 	$ gemini load -v my.vcf -t snpEff my.db
 
-As each variant is loaded into the ``gemini`` database framework, it is being 
-compared against several annotation files that come installed with the software.  
-We have developed an annotation framework that leverages 
-`tabix <http://sourceforge.net/projects/samtools/files/tabix/>`_, 
-`bedtools <http://bedtools.googlecode.com>`_, and 
-`pybedtools <http://pythonhosted.org/pybedtools/>`_ to make things easy and 
+As each variant is loaded into the ``gemini`` database framework, it is being
+compared against several annotation files that come installed with the software.
+We have developed an annotation framework that leverages
+`tabix <http://sourceforge.net/projects/samtools/files/tabix/>`_,
+`bedtools <http://bedtools.googlecode.com>`_, and
+`pybedtools <http://pythonhosted.org/pybedtools/>`_ to make things easy and
 fairly performant. The idea is that, by augmenting VCF files with many
-informative annotations, and converting the information into a ``sqlite`` 
-database framework, ``gemini`` provides a flexible 
-database-driven API for data exploration, visualization, population genomics 
+informative annotations, and converting the information into a ``sqlite``
+database framework, ``gemini`` provides a flexible
+database-driven API for data exploration, visualization, population genomics
 and medical genomics.  We feel that this ability to integrate variation
-with the growing wealth of genome annotations is the most compelling aspect of 
-``gemini``.  Combining this with the ability to explore data with SQL 
+with the growing wealth of genome annotations is the most compelling aspect of
+``gemini``.  Combining this with the ability to explore data with SQL
 using a database design that can scale to 1000s of individuals (genotypes too!)
 makes for a nice, standardized data exploration system.
 
@@ -55,16 +55,16 @@ Using multiple CPUS for loading
 
 Now, the loading step is very computationally intensive and thus can be very slow
 with just a single core.  However, if you have more CPUs in your arsenal,
-you specify more cores.  This provides a roughly linear increase in speed as a 
-function of the number of cores. On our local machine, we are able to load a 
-VCF file derived from the exomes of 60 samples in about 10 minutes.  With a 
+you specify more cores.  This provides a roughly linear increase in speed as a
+function of the number of cores. On our local machine, we are able to load a
+VCF file derived from the exomes of 60 samples in about 10 minutes.  With a
 single core, it takes a few hours.
 
 
 .. note::
 
-    Using multiple cores requires that you have both the ``bgzip`` tool from 
-    `tabix <http://sourceforge.net/projects/samtools/files/tabix/>`_ and the 
+    Using multiple cores requires that you have both the ``bgzip`` tool from
+    `tabix <http://sourceforge.net/projects/samtools/files/tabix/>`_ and the
     `grabix <https://github.com/arq5x/grabix>`_ tool installed in your PATH.
 
 .. code-block:: bash
@@ -73,14 +73,14 @@ single core, it takes a few hours.
 
 
 ================================
-Using LSF, SGE and PBS clusters
+Using LSF, SGE and Torque clusters
 ================================
 Thanks to some great work from Brad Chapman and Rory Kirchner, one can also load
-VCF files into gemini in parallel using many cores on LSF, SGE or PBS clusters. One
+VCF files into gemini in parallel using many cores on LSF, SGE or Torque clusters. One
 must simply specify the type of job scheduler your cluster uses and the queue
 name to which your jobs should be submitted.
 
-For example, let's assume you use LSF and a queue named ``preempt_everyone``. 
+For example, let's assume you use LSF and a queue named ``preempt_everyone``.
 Here is all you need to do:
 
 .. code-block:: bash
@@ -101,14 +101,14 @@ If you use SGE, it would look like:
              --sge-queue preempt_everyone \
              my.db
 
-If you use PBS, it would look like: (you guessed it):
+If you use Torque, it would look like: (you guessed it):
 
 .. code-block:: bash
 
     $ gemini load -v my.vcf \
              -t snpEff \
              --cores 50 \
-             --pbs-queue preempt_everyone \
+             --torque-queue preempt_everyone \
              my.db
 
 

--- a/gemini/gemini_load.py
+++ b/gemini/gemini_load.py
@@ -668,7 +668,7 @@ def get_ipython_args(args):
     elif args.sge_queue:
         return ("sge", args.sge_queue, args.cores)
     elif args.torque_queue:
-        return ("pbs", args.pbs_queue, args.cores)
+        return ("torque", args.torque_queue, args.cores)
     else:
         raise ValueError("ipython argument parsing failed for some reason.")
 
@@ -678,7 +678,7 @@ def print_cmd_not_found_and_exit(cmd):
     exit(1)
 
 def use_scheduler(args):
-    if any([args.lsf_queue, args.sge_queue, args.pbs_queue]):
+    if any([args.lsf_queue, args.sge_queue, args.torque_queue]):
         return True
     else:
         return False

--- a/gemini/gemini_main.py
+++ b/gemini/gemini_main.py
@@ -113,9 +113,9 @@ def main():
     parser_load.add_argument('--sge-queue',
             dest='sge_queue',
             help="Queue name to use for Sun Grid Engine.")
-    parser_load.add_argument('--pbs-queue',
-            dest='pbs_queue',
-            help="Queue name to use for a PBS based scheduler (Torque/PBS Pro)")
+    parser_load.add_argument('--torque-queue',
+            dest='torque_queue',
+            help="Queue name to use for a Torque based scheduler")
 
     parser_load.set_defaults(func=gemini_load.load)
 


### PR DESCRIPTION
1) Swapped IPython to use the piping style loading, which is significantly faster.
2) Refactored the loading step a little bit to remove some unused functions.
3) Cluster startup refactored: Only spin up one cluster, then pass a view to it, to save on the cluster startup time for a busy scheduler.
4) Added Torque support and removed generic PBS support.

This closes https://github.com/arq5x/gemini/issues/84 and https://github.com/arq5x/gemini/issues/83.
