### PR TITLE
Annotation for context specific sequencing error regions

### DIFF
--- a/docs/content/database_schema.rst
+++ b/docs/content/database_schema.rst
@@ -185,7 +185,7 @@ recomb_rate               FLOAT         | Returns the mean recombination rate at
 
 
 
-Mappability
+Variant error assessment
 ........................
 ========================  ========      ==============================================================================================
 ========================  ========      ==============================================================================================
@@ -201,6 +201,10 @@ gms_illumina              FLOAT         | Genome Mappability Scores (GMS) for Il
                                         | https://github.com/chapmanb/bcbio.variation/blob/master/src/bcbio/variation/utils/gms.clj
 gms_solid                 FLOAT         Genome Mappability Scores with SOLiD error models
 gms_iontorrent            FLOAT         Genome Mappability Scores with IonTorrent error models
+in_cse                    BOOL          | Is a variant in an error prone genomic position,
+                                        | using CSE: Context-Specific Sequencing Errors 
+                                        | https://code.google.com/p/discovering-cse/
+                                        | http://www.biomedcentral.com/1471-2105/14/S5/S1
 ========================  ========      ==============================================================================================
 
 

--- a/gemini/annotation_provenance/make-cse.sh
+++ b/gemini/annotation_provenance/make-cse.sh
@@ -1,0 +1,9 @@
+# CSE: Context specific error regions
+# https://code.google.com/p/discovering-cse/
+
+wget https://discovering-cse.googlecode.com/files/cse-tracks.tar.gz
+tar -xzvpf cse-tracks.tar.gz
+cd cse-tracks
+mv HiSeq-hg-8_4.bed cse-hiseq-8_4-2013-02-20.bed
+bgzip cse-hiseq-8_4-2013-02-20.bed
+tabix -p bed cse-hiseq-8_4-2013-02-20.bed.gz

--- a/gemini/annotations.py
+++ b/gemini/annotations.py
@@ -144,6 +144,7 @@ def load_annos():
         'gms': os.path.join(anno_dirname,
                             'GRCh37-gms-mappability.vcf.gz'),
         'grc': os.path.join(anno_dirname, 'GRC_patch_regions.bed.gz'),
+        'cse': os.path.join(anno_dirname, "cse-hiseq-8_4-2013-02-20.bed.gz"),
         'encode_tfbs': os.path.join(anno_dirname,
                                     'wgEncodeRegTfbsClusteredV2.cell_count.20130213.bed.gz'),
         'encode_dnase1': os.path.join(anno_dirname,
@@ -506,6 +507,12 @@ def get_grc(var):
         regions.add(hit.name)
     return ",".join(sorted(list(regions))) if len(regions) > 0 else None
 
+def get_cse(var):
+    """Return if a variant is in a CSE: Context-specific error region.
+    """
+    for hit in annotations_in_region(var, "cse", "bed", "grch37"):
+        return True
+    return False
 
 def get_encode_tfbs(var):
     """

--- a/gemini/database.py
+++ b/gemini/database.py
@@ -141,6 +141,7 @@ def create_tables(cursor):
                     gms_illumina float,                         \
                     gms_solid float,                            \
                     gms_iontorrent float,                       \
+                    in_cse bool,                                \
                     encode_tfbs text,                           \
                     encode_dnaseI_cell_count integer,           \
                     encode_dnaseI_cell_list text,               \
@@ -245,7 +246,7 @@ def insert_variation(cursor, buffer):
                                                          ?,?,?,?,?,?,?,?,?,?, \
                                                          ?,?,?,?,?,?,?,?,?,?, \
                                                          ?,?,?,?,?,?,?,?,?,?, \
-                                                         ?)', buffer)
+                                                         ?,?)', buffer)
         cursor.execute("END TRANSACTION")
     except sqlite3.ProgrammingError:
         cursor.execute("END TRANSACTION")

--- a/gemini/gemini_load_chunk.py
+++ b/gemini/gemini_load_chunk.py
@@ -221,6 +221,7 @@ class GeminiLoader(object):
         recomb_rate = annotations.get_recomb_info(var)
         gms = annotations.get_gms(var)
         grc = annotations.get_grc(var)
+        in_cse = annotations.get_cse(var)
         encode_tfbs = annotations.get_encode_tfbs(var)
         encode_dnaseI = annotations.get_encode_dnase_clusters(var)
         encode_cons_seg = annotations.get_encode_consensus_segs(var)
@@ -344,7 +345,7 @@ class GeminiLoader(object):
                    esp.aaf_AA, esp.aaf_ALL, esp.exome_chip, thousandG.found,
                    thousandG.aaf_AMR, thousandG.aaf_ASN, thousandG.aaf_AFR,
                    thousandG.aaf_EUR, thousandG.aaf_ALL, grc,
-                   gms.illumina, gms.solid, gms.iontorrent,
+                   gms.illumina, gms.solid, gms.iontorrent, in_cse,
                    encode_tfbs,
                    encode_dnaseI.cell_count,
                    encode_dnaseI.cell_list,

--- a/gemini/install-data.py
+++ b/gemini/install-data.py
@@ -43,6 +43,8 @@ anno_files = \
 'hprd_interaction_graph'
 ]
 
+toadd_anno_files = ["cse-hiseq-8_4-2013-02-20.bed.gz"]
+
 anno_versions = {
     "GRCh37-gms-mappability.vcf.gz": 2,
     "hg19.rmsk.bed.gz": 2}
@@ -63,14 +65,21 @@ def install_annotation_files(anno_root_dir):
 
     cur_config = read_gemini_config(allow_missing=True)
 
-    # download and install each of the annotation files
-    for orig in anno_files:
+    _download_anno_files("http://people.virginia.edu/~arq5x/files/gemini/annotations",
+                         anno_files, cur_config)
+    _download_anno_files("https://s3.amazonaws.com/chapmanb/gemini",
+                         toadd_anno_files, cur_config)
+
+def _download_anno_files(base_url, file_names, cur_config):
+    """Download and install each of the annotation files
+    """
+    for orig in file_names:
         if orig.endswith(".gz"):
             dls = [orig, "%s.tbi" % orig]
         else:
             dls = [orig]
         for dl in dls:
-            url = "http://people.virginia.edu/~arq5x/files/gemini/annotations/{fname}".format(fname=dl)
+            url = "{base_url}/{fname}".format(fname=dl, base_url=base_url)
             _download_to_dir(url, anno_dir, anno_versions.get(orig, 1),
                              cur_config.get("versions", {}).get(orig, 1))
 


### PR DESCRIPTION
Aaron;
In our continued quest for diagnostics to help identify potential false positives, this integrates regions associated with sequencing errors from a recent paper Oliver spotted in BMC Bioinformatics:

http://www.biomedcentral.com/1471-2105/14/S5/S1
https://code.google.com/p/discovering-cse/

This adds docs, provenance and database updates. At some point the annotation files will need to be moved over to the main repo but should work cleanly as is from my AWS S3 bucket.
