### PR TITLE
Slightly faster annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,11 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+
+# gemini-specific detritus from unit testing
+test/*.db
+test/exp
+test/obs
+
+# emacs temporary file
+.#*


### PR DESCRIPTION
This could use more speedups; it takes 10-15 hours or so to add a small file to a 1k genomes database. This at least makes it usable on larger databases, before it was taking infinity time.

I think it might be faster to load the BED file as a temporary table and join on it. My SQL kung fu is weak so I'll need a little more time to see if I can get something like that working for each of the annotation cases.
