### PR TITLE
Fix bug in specifying download directory to install-data

### DIFF
--- a/gemini/install-data.py
+++ b/gemini/install-data.py
@@ -69,11 +69,11 @@ def install_annotation_files(anno_root_dir):
     cur_config = read_gemini_config(allow_missing=True)
 
     _download_anno_files("https://s3.amazonaws.com/gemini-annotations",
-                         anno_files, cur_config)
-    _download_anno_files("https://s3.amazonaws.com/chapmanb/gemini",
-                         toadd_anno_files, cur_config)
+                         anno_files, anno_dir, cur_config)
+    #_download_anno_files("https://s3.amazonaws.com/chapmanb/gemini",
+    #                     toadd_anno_files, cur_config)
 
-def _download_anno_files(base_url, file_names, cur_config):
+def _download_anno_files(base_url, file_names, anno_dir, cur_config):
     """Download and install each of the annotation files
     """
     for orig in file_names:


### PR DESCRIPTION
Aaron;
Apologies, there was a little bug in my code to generalize the downloads and it was no longer using the annotation subdirectory (gemini/data) to stick all of the data in. This fixes this by passing the created annotation directory to the download function.
