### PR TITLE
Fix for bx-python build issue and potential fix for bottle.py import error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ python-graph-core==1.8.2
 python-graph-dot==1.8.2
 bottle==0.11.6
 ipython-cluster-helper==0.1.5
+bx-python>=0.7.1
 git+https://github.com/arq5x/gemini.git@5cf3db1944#egg=gemini


### PR DESCRIPTION
Aaron;
This provides an explicit bx-python build which should fix issue #143.

For issue #144, it removes the extra bottle.py(c) in the bin directory to avoid the double import. I'm not sure if this is causing the segfault, but it will at least remove the warning. For gemini we don't need to run bottle from the commandline, so only need the version in site-packages.
