### PR TITLE
Fixes for reported installation issues

### DIFF
--- a/gemini/annotations.py
+++ b/gemini/annotations.py
@@ -11,12 +11,13 @@ from bx.bbi.bigwig_file import BigWigFile
 from gemini.config import read_gemini_config
 
 # dictionary of anno_type -> open Tabix file handles
-config = read_gemini_config()
-anno_dirname = config["annotation_dir"]
 annos = {}
 
-anno_files = {
-    'pfam_domain': os.path.join(anno_dirname, 'hg19.pfam.ucscgenes.bed.gz'),
+def get_anno_files():
+    config = read_gemini_config()
+    anno_dirname = config["annotation_dir"]
+    return {
+     'pfam_domain': os.path.join(anno_dirname, 'hg19.pfam.ucscgenes.bed.gz'),
     'cytoband': os.path.join(anno_dirname, 'hg19.cytoband.bed.gz'),
     'dbsnp': os.path.join(anno_dirname, 'dbsnp.137.vcf.gz'),
     'clinvar': os.path.join(anno_dirname, 'clinvar_20130118.vcf.gz'),
@@ -44,7 +45,7 @@ anno_files = {
                                           'encode.6celltypes.consensus.bedg.gz'),
     'gerp_bp': os.path.join(anno_dirname, 'hg19.gerp.bw'),
     'gerp_elements': os.path.join(anno_dirname, 'hg19.gerp.elements.bed.gz'),
-}
+    }
 
 class ClinVarInfo(object):
     def __init__(self):
@@ -156,7 +157,8 @@ def load_annos():
     dbsnp_handle = annotations.annos['dbsnp']
     hits = dbsnp_handle.fetch(chrom, start, end)
     """
-    for anno in anno_files:
+    anno_files = get_anno_files()
+    for anno in anno_files: 
         try:
             # .gz denotes Tabix files.
             if anno_files[anno].endswith(".gz"):
@@ -651,4 +653,5 @@ def get_encode_chromhmm_segs(var):
 def get_resources():
     """Retrieve list of annotation resources loaded into gemini.
     """
+    anno_files = get_anno_files()
     return [(n, os.path.basename(anno_files[n])) for n in sorted(anno_files.keys())]

--- a/gemini/config.py
+++ b/gemini/config.py
@@ -32,8 +32,10 @@ def _get_config_file(dirs=None):
         fname = os.path.join(dname, CONFIG_FILE)
         if os.path.exists(fname):
             return fname
-    raise ValueError("Gemini configuration file {0} not found in {1}".format(
-        CONFIG_FILE, dnames))
+    raise ValueError("GEMINI configuration file {0} not found in {1}.\n"
+                     "Please ensure the GEMINI data is installed using the install-data.py script\n"
+                     "http://gemini.readthedocs.org/en/latest/content/installation.html"
+                     .format(CONFIG_FILE, dnames))
 
 def read_gemini_config(dirs=None, allow_missing=False):
     try:

--- a/gemini/tool_interactions.py
+++ b/gemini/tool_interactions.py
@@ -24,9 +24,6 @@ import gemini_utils as util
 from gemini_constants import *
 from collections import defaultdict
 
-config = read_gemini_config()
-path_dirname = config["annotation_dir"]
-
 def get_variant_genes(c, args, idx_to_sample):
     samples = defaultdict(list)
     for r in c:
@@ -75,6 +72,8 @@ def sample_gene_interactions(c, args, idx_to_sample):
     #fetch variant gene dict for all samples
     samples = get_variant_genes(c, args, idx_to_sample)
     #file handle for fetching the hprd graph
+    config = read_gemini_config()
+    path_dirname = config["annotation_dir"]
     file_graph = os.path.join(path_dirname, 'hprd_interaction_graph')
     #load the graph using cPickle and close file handle
     gr = graph()
@@ -147,6 +146,8 @@ def sample_gene_interactions(c, args, idx_to_sample):
 def sample_lof_interactions(c, args, idx_to_sample, samples):
     lof = get_lof_genes(c, args, idx_to_sample)
     #file handle for fetching the hprd graph
+    config = read_gemini_config()
+    path_dirname = config["annotation_dir"]
     file_graph = os.path.join(path_dirname, 'hprd_interaction_graph')
     #load the graph using cPickle and close file handle
     gr = graph()

--- a/gemini/tool_lof_sieve.py
+++ b/gemini/tool_lof_sieve.py
@@ -1,17 +1,10 @@
 #!/usr/bin/env python
 
 import os
-import sys
 import re
 import sqlite3
-from collections import defaultdict
-from gemini.config import read_gemini_config
 import gemini_utils as util
 from gemini_constants import *
-
-
-config = read_gemini_config()
-path_dirname = config["annotation_dir"]
 
 
 def get_ind_lof(c, args):

--- a/gemini/tool_pathways.py
+++ b/gemini/tool_pathways.py
@@ -11,8 +11,6 @@ from gemini.config import read_gemini_config
 import gemini_utils as util
 from gemini_constants import *
 
-config = read_gemini_config()
-path_dirname = config["annotation_dir"]
 
 
 def get_pathways(args):
@@ -22,6 +20,8 @@ def get_pathways(args):
                    '68': 'kegg_pathways_ensembl68', '69': 'kegg_pathways_ensembl69',
                    '70': 'kegg_pathways_ensembl70', '71': 'kegg_pathways_ensembl71'}
     
+    config = read_gemini_config()
+    path_dirname = config["annotation_dir"]
     if args.version in version_dic:
         path_file = os.path.join(path_dirname, version_dic[args.version])
          

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ pybedtools==0.6.2
 python-graph-core==1.8.2
 python-graph-dot==1.8.2
 bottle==0.11.6
-ipython-cluster-helper==0.1.5
+ipython-cluster-helper==0.1.6
 bx-python>=0.7.1
 git+https://github.com/arq5x/gemini.git@83fe05c051#egg=gemini

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
                           'python-graph-core >= 1.8.2',
                           'python-graph-dot >= 1.8.2',
                           'bottle >= 0.11',
-                          'ipython-cluster-helper',
+                          'ipython-cluster-helper >= 0.1.6',
                           'bx-python >= 0.7.1'],
         dependency_links = ['http://github.com/arq5x/cyvcf/tarball/master#egg=cyvcf-0.1.5'],
         requires = ['python (>=2.5, <3.0)'],


### PR DESCRIPTION
Aaron;
This handles issues reported by Amit Indap on the mailing list:
- Now requires only IPython 0.13.2 instead of the development version.
- Provide a better error message for missing configuration files, pointing users at possibility of missing data files.
-  Only require configured data when doing loading to allow other functionality to work without data files. This opens up the possibility of having a "lite" gemini install that queries an existing database without needing all the associated files for creating new databases. It moves the configuration loading to run time instead of globally at import time.
