### PR TITLE
Installation fixes: bump pysam and cyvcf versions and allow 'gemini update' even if initial installer fails on installing data

### DIFF
--- a/gemini/install-data.py
+++ b/gemini/install-data.py
@@ -76,6 +76,10 @@ def install_annotation_files(anno_root_dir):
 def _download_anno_files(base_url, file_names, anno_dir, cur_config):
     """Download and install each of the annotation files
     """
+    cur_config["annotation_dir"] = os.path.abspath(anno_dir)
+    cur_config["versions"] = anno_versions
+    write_gemini_config(cur_config)
+
     for orig in file_names:
         if orig.endswith(".gz"):
             dls = [orig, "%s.tbi" % orig]
@@ -85,10 +89,6 @@ def _download_anno_files(base_url, file_names, anno_dir, cur_config):
             url = "{base_url}/{fname}".format(fname=dl, base_url=base_url)
             _download_to_dir(url, anno_dir, anno_versions.get(orig, 1),
                              cur_config.get("versions", {}).get(orig, 1))
-
-    cur_config["annotation_dir"] = os.path.abspath(anno_dir)
-    cur_config["versions"] = anno_versions
-    write_gemini_config(cur_config)
 
 def _download_to_dir(url, dirname, version, cur_version):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.7.1
 pyparsing==1.5.7
-pysam==0.6
-git+https://github.com/arq5x/cyvcf.git@a4d23dee90#egg=cyvcf
+pysam==0.7.4
+cyvcf==0.1.6
 PyYAML==3.10
 pybedtools==0.6.2
 python-graph-core==1.8.2

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
         version=version,
         install_requires=['numpy>=1.6.0', 
                           'pyparsing>=1.5.6,<=1.5.7', 
-                          'pysam>=0.6',
+                          'pysam>=0.7.4',
                           'cyvcf>=0.1.6', 
                           'PyYAML >= 3.10', 
                           'pybedtools>=0.6.1',


### PR DESCRIPTION
Aaron;
This bumps pysam and cyvcf to handle the installation issues we discussed (https://github.com/arq5x/gemini/issues/144). It also writes the gemini configuration file earlier in the process. This allows folks to do a gemini update even if the initial set of downloads failed, making redoing problematic installs easier. Now the fix is always: try a `gemini update`
