### PR TITLE
Bumps cyvcf versions to include fixed installation version from pypi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.7.1
 pyparsing==1.5.7
 pysam==0.7.4
-cyvcf==0.1.6
+cyvcf==0.1.7
 PyYAML==3.10
 pybedtools==0.6.2
 python-graph-core==1.8.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
         install_requires=['numpy>=1.6.0', 
                           'pyparsing>=1.5.6,<=1.5.7', 
                           'pysam>=0.7.4',
-                          'cyvcf>=0.1.6', 
+                          'cyvcf>=0.1.7', 
                           'PyYAML >= 3.10', 
                           'pybedtools>=0.6.1',
                           'python-graph-core >= 1.8.2',


### PR DESCRIPTION
Aaron;
Part 2 of the fix for @udp3f: actually bumping to the new version in Gemini. Sorry about the issues with the previous pypi build.
