### PR TITLE
Clarified the --allow-other-hets option

### DIFF
--- a/docs/content/tools.rst
+++ b/docs/content/tools.rst
@@ -51,9 +51,9 @@ restrict the analysis to LoF variants using the ``--only_lof`` option.
 ``--allow-other-hets``
 ----------------------
 By default, the ``comp_hets`` tool will identify candidate pairs of
-heterozygotes that are found in *only one* of the samples in your database.
+heterozygotes where each variant is found in *only one* of the samples in your database.
 Depending on the genetic model, this may be too restrictive.  If you'd like to
-identify candidates where other individuals may also be heterozygous, just use
+include variants for which other individuals may also be heterozygous, just use
 the ``--allow-other-hets`` option
 
 .. code-block:: bash


### PR DESCRIPTION
I understood it to mean that if >1 person was compound het for a pair of variants, the variants were excluded (vs if >1 person is het any variant, that variant is excluded).
