### PR TITLE
Update database_schema.rst

### DIFF
--- a/docs/content/database_schema.rst
+++ b/docs/content/database_schema.rst
@@ -126,7 +126,7 @@ Population information
 ........................
 ========================  ========      ==============================================================================================
 ========================  ========      ==============================================================================================
-in_dbsnp                  BOOL          | Is this variant found in dbSnp (build 135)?
+in_dbsnp                  BOOL          | Is this variant found in dbSnp (build 137)?
                                         | 0 : Absence of the variant in dbsnp
                                         | 1 : Presence of the variant in dbsnp
 rs_ids                    STRING        | A comma-separated list of rs ids for variants present in dbsnp


### PR DESCRIPTION
dbsnp updated to version 137

would be good to support in_dbsnp132 for variant evaluation purpose, ts/tv ratio of novel snp is quite low when we use dbsnp137 to define 'known' snp
