### PR TITLE
Remove ORDER BY.

### DIFF
--- a/gemini/gemini_inheritance_model_utils.py
+++ b/gemini/gemini_inheritance_model_utils.py
@@ -61,7 +61,7 @@ class GeminiInheritanceModelFactory(object):
         for family in families:
 
             family_filter = None
-            
+
             if self.model == "auto_rec":
                 family_filter = family.get_auto_recessive_filter()
             elif self.model == "auto_dom":
@@ -93,14 +93,14 @@ class GeminiInheritanceModelFactory(object):
         # add any non-genotype column limits to the where clause
         if self.args.filter:
             self.query += " WHERE " + self.args.filter
-        
+
         # auto_rec and auto_dom candidates should be limited to
         # variants affecting genes.
         if self.model == "auto_rec" or self.model == "auto_dom":
             if self.args.filter:
-                self.query += " AND gene is not NULL ORDER BY gene"
+                self.query += " AND gene is not NULL"
             else:
-                self.query += " WHERE gene is not NULL ORDER BY gene"
+                self.query += " WHERE gene is not NULL"
 
     def _get_gene_only_candidates(self):
         """
@@ -123,7 +123,7 @@ class GeminiInheritanceModelFactory(object):
         for row in self.gq:
 
             curr_gene = row['gene']
-        
+
             # report any candidates for the previous gene
             if curr_gene != prev_gene and prev_gene is not None:
                 self._report_candidates()
@@ -136,7 +136,7 @@ class GeminiInheritanceModelFactory(object):
                 family_gt_labels = self.family_gt_labels[idx]
                 family_gt_cols = self.family_gt_columns[idx]
 
-                # interrogate the genotypes present in each family member to 
+                # interrogate the genotypes present in each family member to
                 # conforming to the genetic model being tested
                 gt_types = row['gt_types']
                 gts = row['gts']
@@ -145,19 +145,19 @@ class GeminiInheritanceModelFactory(object):
                 # for this family
                 if not eval(family_genotype_mask):
                     continue
-                    
+
 
                 # if it meets a recessive model, add it to the list
                 # of candidates for this gene.
                 self.candidates[(curr_gene, fam_id)].append((row,
-                                                        family_gt_labels, 
+                                                        family_gt_labels,
                                                         family_gt_cols))
 
             prev_gene = curr_gene
-    
+
         # report any candidates for the last gene
         self._report_candidates()
-        
+
     def _get_all_candidates(self):
         """
         Identify candidates that meet the user's criteria no matter where
@@ -185,7 +185,7 @@ class GeminiInheritanceModelFactory(object):
                 family_gt_labels = self.family_gt_labels[idx]
                 family_gt_cols = self.family_gt_columns[idx]
 
-                # interrogate the genotypes present in each family member to 
+                # interrogate the genotypes present in each family member to
                 # conforming to the genetic model being tested
                 gt_types = row['gt_types']
                 gts = row['gts']


### PR DESCRIPTION
Hi Aaron and Uma,

These queries fail with out an out of disk space error for very large databases; I know very little about sqlite, but it seems like if the database is created with journaling in memory, if it has to write a large temporary table it will run out of memory. I was getting: SQLite error: database or disk is full errors running these queries, even with my tmp dir set to filesystems with 100T plus of space. Removing ORDER BY seems to fix it; https://www.sqlite.org/tempfiles.html kind of indicates in passing that a temporary table will be created for ORDER BY clauses. I think the solution would be either to not set the journaling to be in memory or to remove ORDER BY clauses where the result might be very large. I'm pull requesting to see what you think.
