### PR TITLE
implement the --annotation-dir argument

### DIFF
--- a/gemini/annotations.py
+++ b/gemini/annotations.py
@@ -12,8 +12,8 @@ from gemini.config import read_gemini_config
 # dictionary of anno_type -> open Tabix file handles
 annos = {}
 
-def get_anno_files():
-    config = read_gemini_config()
+def get_anno_files( args ):
+    config = read_gemini_config( args = args )
     anno_dirname = config["annotation_dir"]
     # Default annotations -- always found
     annos = {
@@ -153,7 +153,7 @@ ThousandGInfo = collections.namedtuple("ThousandGInfo",
                                         aaf_AFR \
                                         aaf_EUR")
 
-def load_annos():
+def load_annos( args ):
     """
     Populate a dictionary of Tabixfile handles for
     each annotation file.  Other modules can then
@@ -163,7 +163,7 @@ def load_annos():
     dbsnp_handle = annotations.annos['dbsnp']
     hits = dbsnp_handle.fetch(chrom, start, end)
     """
-    anno_files = get_anno_files()
+    anno_files = get_anno_files( args )
     for anno in anno_files: 
         try:
             # .gz denotes Tabix files.
@@ -784,8 +784,8 @@ def get_encode_chromhmm_segs(var):
     return ENCODESegInfo(None, None, None, None, None, None)
 
 
-def get_resources():
+def get_resources( args ):
     """Retrieve list of annotation resources loaded into gemini.
     """
-    anno_files = get_anno_files()
+    anno_files = get_anno_files( args )
     return [(n, os.path.basename(anno_files[n])) for n in sorted(anno_files.keys())]

--- a/gemini/config.py
+++ b/gemini/config.py
@@ -42,7 +42,7 @@ def _get_config_file(dirs=None, use_globals=True):
                      "http://gemini.readthedocs.org/en/latest/content/installation.html"
                      .format(CONFIG_FILE, dnames))
 
-def read_gemini_config(dirs=None, allow_missing=False, use_globals=True):
+def read_gemini_config(dirs=None, allow_missing=False, use_globals=True, args=None):
     try:
         fname = _get_config_file(dirs, use_globals=use_globals)
     except ValueError:
@@ -51,7 +51,12 @@ def read_gemini_config(dirs=None, allow_missing=False, use_globals=True):
         else:
             raise
     with open(fname) as in_handle:
-        return yaml.load(in_handle)
+        config = yaml.load(in_handle)
+    if args and args.annotation_dir:
+        # If --annotation-dir is given via commandline interface, we will overwrite the
+        # location from the config file
+        config["annotation_dir"] = args.annotation_dir
+    return config
 
 def _find_best_config_file(dirs=None):
     dirs = [] if dirs is None else dirs

--- a/gemini/gemini_load.py
+++ b/gemini/gemini_load.py
@@ -21,7 +21,7 @@ def load(parser, args):
         parser.print_help()
         exit("ERROR: load needs both a VCF file and a database file\n")
 
-    annos = annotations.get_anno_files()
+    annos = annotations.get_anno_files( args )
     # force skipping CADD and GERP if the data files have not been installed
     if args.skip_cadd is False:
         if 'cadd_score' not in annos:
@@ -41,7 +41,7 @@ def load(parser, args):
         else:
             sys.stderr.write("GERP per bp is being loaded (to skip use:--skip-gerp-bp).\n")
     # collect of the the add'l annotation files
-    annotations.load_annos()
+    annotations.load_annos( args )
 
     if args.scheduler:
         load_ipython(args)

--- a/gemini/gemini_load_chunk.py
+++ b/gemini/gemini_load_chunk.py
@@ -64,7 +64,7 @@ class GeminiLoader(object):
     def store_resources(self):
         """Create table of annotation resources used in this gemini database.
         """
-        database.insert_resources(self.c, annotations.get_resources())
+        database.insert_resources(self.c, annotations.get_resources( self.args ))
 
     def store_version(self):
         """Create table documenting which gemini version was used for this db.
@@ -511,7 +511,7 @@ class GeminiLoader(object):
         i = 0
         table_contents = detailed_list = []
         
-        config = read_gemini_config()
+        config = read_gemini_config( args = self.args )
         path_dirname = config["annotation_dir"]
         file_handle = os.path.join(path_dirname, 'detailed_gene_table_v75')
         
@@ -537,7 +537,7 @@ class GeminiLoader(object):
         i = 0
         contents = summary_list = []
         
-        config = read_gemini_config()
+        config = read_gemini_config( args = self.args )
         path_dirname = config["annotation_dir"]
         file = os.path.join(path_dirname, 'summary_gene_table_v75')
         
@@ -560,7 +560,7 @@ class GeminiLoader(object):
     def update_gene_table(self):
         """
         """
-        gene_table.update_cosmic_census_genes(self.c)
+        gene_table.update_cosmic_census_genes(self.c, self.args)
 
     def _init_sample_gt_counts(self):
         """
@@ -609,7 +609,7 @@ def load(parser, args):
         exit("\nERROR: Unsupported selection for -t\n")
 
     # collect of the the add'l annotation files
-    annotations.load_annos()
+    annotations.load_annos( args )
 
     # create a new gemini loader and populate
     # the gemini db and files from the VCF

--- a/gemini/gemini_main.py
+++ b/gemini/gemini_main.py
@@ -53,6 +53,9 @@ def main():
     parser.add_argument("-v", "--version", help="Installed gemini version",
                         action="version",
                         version="%(prog)s " + str(gemini.version.__version__))
+    parser.add_argument('--annotation-dir', dest='annotation_dir',
+                             help='Path to the annotation database.\n'
+                                'This argument is optional and if given will take precedence over the default location stored in the gemini config file.')
     subparsers = parser.add_subparsers(title='[sub-commands]', dest='command')
 
     #########################################

--- a/gemini/gemini_update.py
+++ b/gemini/gemini_update.py
@@ -58,7 +58,7 @@ def release(parser, args):
                                    "git+%s" % repo])
         print "Gemini upgraded to latest version"
     # update datafiles
-    config = gemini.config.read_gemini_config()
+    config = gemini.config.read_gemini_config( args = args )
     extra_args = ["--extra=%s" % x for x in args.extra]
     subprocess.check_call([sys.executable, _get_install_script(), config["annotation_dir"]] + extra_args)
     print "Gemini data files updated"

--- a/gemini/gene_table.py
+++ b/gemini/gene_table.py
@@ -52,13 +52,13 @@ class gene_summary:
         return ",".join([self.chrom, self.gene, self.is_hgnc, self.ensembl_gene_id, self.hgnc_id, self.synonym, self.rvis, 
                          self.strand, self.transcript_min_start, self.transcript_max_end, self.mam_phenotype])
          
-def update_cosmic_census_genes(cursor):
+def update_cosmic_census_genes( cursor, args ):
     """
     Update the gene summary table with
     whether or not a given gene is in the
     COSMIC cancer gene census
     """
-    config = read_gemini_config()
+    config = read_gemini_config( args= args )
     path_dirname = config["annotation_dir"]
     file = os.path.join(path_dirname, 'cancer_gene_census.20140120.tsv')
     

--- a/gemini/tool_interactions.py
+++ b/gemini/tool_interactions.py
@@ -72,7 +72,7 @@ def sample_gene_interactions(c, args, idx_to_sample):
     #fetch variant gene dict for all samples
     samples = get_variant_genes(c, args, idx_to_sample)
     #file handle for fetching the hprd graph
-    config = read_gemini_config()
+    config = read_gemini_config( args = args )
     path_dirname = config["annotation_dir"]
     file_graph = os.path.join(path_dirname, 'hprd_interaction_graph')
     #load the graph using cPickle and close file handle
@@ -146,7 +146,7 @@ def sample_gene_interactions(c, args, idx_to_sample):
 def sample_lof_interactions(c, args, idx_to_sample, samples):
     lof = get_lof_genes(c, args, idx_to_sample)
     #file handle for fetching the hprd graph
-    config = read_gemini_config()
+    config = read_gemini_config( args = args )
     path_dirname = config["annotation_dir"]
     file_graph = os.path.join(path_dirname, 'hprd_interaction_graph')
     #load the graph using cPickle and close file handle

--- a/gemini/tool_pathways.py
+++ b/gemini/tool_pathways.py
@@ -20,7 +20,7 @@ def get_pathways(args):
                    '68': 'kegg_pathways_ensembl68', '69': 'kegg_pathways_ensembl69',
                    '70': 'kegg_pathways_ensembl70', '71': 'kegg_pathways_ensembl71'}
 
-    config = read_gemini_config()
+    config = read_gemini_config( args = args )
     path_dirname = config["annotation_dir"]
     if args.version in version_dic:
         path_file = os.path.join(path_dirname, version_dic[args.version])


### PR DESCRIPTION
Implementing the --annotation-dir argument. With this argument you can overwrite the location of the annotation directory obtained from the gemini-config.yaml.

This is useful to use different annotations, like different annotation versions.
The argument is optional ans was discussed in https://github.com/arq5x/gemini/issues/316
