### PR TITLE
use _safe_single_attr wrapper also for the map qualities

### DIFF
--- a/gemini/infotag.py
+++ b/gemini/infotag.py
@@ -110,7 +110,7 @@ def get_map_qual_zero(var):
     Return the total counts of mapping quality zero reads,
     or None if it isn't present in the VCF.
     """
-    return var.INFO.get('MQ0')
+    return _safe_single_attr(var.INFO.get('MQ0'))
 
 
 def get_num_of_alleles(var):


### PR DESCRIPTION
My merged VCF file ended up with an SQL error and I was able to track it down to the following variant.
This pull request should fix it.

```
'LOW', None, None, None, None, None, None, None, 8, None, 37.12, None, [0], 
4, None, None, '11.92', 2, None, None, None, None, False, 
None, None, None, False, True, '0.01', None, '0.07', None, '0.02', 
None, None, None, None, False, None, None, None, 'T', 'R', 
'R', 'R', 'R', 'T', None, None, 
<read-only buffer for 0x7f3431654318, size -1, offset 0 at 0x7f3431673970>, '-0.53', '1.59']
```
