### PR TITLE
WIP: Annotate With a VCF. Pulls from the INFO field

### DIFF
--- a/gemini/gemini_main.py
+++ b/gemini/gemini_main.py
@@ -515,7 +515,7 @@ def main():
             help='Operation(s) to apply to the extract column values '
                   'in the event that a variant overlaps multiple annotations '
                   'in your annotation file (-f).'
-                  'Any of {mean, median, min, max, mode, list, uniq_list, first, last}')
+                  'Any of {sum, mean, median, min, max, mode, list, uniq_list, first, last}')
     def annotate_fn(parser, args):
         import gemini_annotate
         gemini_annotate.annotate(parser, args)

--- a/gemini/gemini_main.py
+++ b/gemini/gemini_main.py
@@ -494,7 +494,8 @@ def main():
             help='The TABIX\'ed BED file containing the annotations')
     parser_get.add_argument('-c',
             dest='col_names',
-            help='The name(s) of the column(s) to be added to the variant table.')
+            help='The name(s) of the BED column(s) to be added to the variant table.'
+            'If the input file is a VCF, then this is the name of the info field to pull.')
     parser_get.add_argument('-a',
             dest='anno_type',
             help='How should the annotation file be used? (def. extract)',
@@ -502,7 +503,8 @@ def main():
             choices=['boolean', 'count', 'extract'])
     parser_get.add_argument('-e',
             dest='col_extracts',
-            help='Column(s) to extract information from for list annotations.')
+            help='Column(s) to extract information from for list annotations.'
+            'If the input is VCF, then this defaults to the fields specified in `-c`.')
     parser_get.add_argument('-t',
             dest='col_types',
             help='What data type(s) should be used to represent the new values '

--- a/test/test-annotate-tool-vcf.sh
+++ b/test/test-annotate-tool-vcf.sh
@@ -237,3 +237,22 @@ chr1	69761	88.0	1.333
 chr1	69871	80.0	-0.646" > exp
 
 check obs exp test-annotate-vcf.t10
+
+
+## test multiple columns with alternate names
+gemini annotate -f test.anno.vcf.gz -t float,float -e AN,BaseQRankSum -c abc,def -o mean,list test.snpeff.vcf.db 
+gemini query --header -q "select chrom, end, abc, def from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	abc	def
+chr1	30548	14.0	0.0
+chr1	30860	52.0	2.815
+chr1	30869	56.0	0.9
+chr1	30895	58.0	-0.23
+chr1	30923	30.0	None
+chr1	69270	56.0	1.675
+chr1	69428	106.0	-0.638
+chr1	69511	90.0	-1.592
+chr1	69761	88.0	1.333
+chr1	69871	80.0	-0.646" > exp
+
+check obs exp test-annotate-vcf.t11

--- a/test/test-annotate-tool-vcf.sh
+++ b/test/test-annotate-tool-vcf.sh
@@ -24,3 +24,198 @@ chr1	69761	88.0
 chr1	69871	80.0" > exp
 
 check obs exp test-annotate-vcf.t01
+
+# make sure a missing field works (1 recoord has not BaseQRankSum
+gemini annotate -f test.anno.vcf.gz -o uniq_list -c BaseQRankSum -t float test.snpeff.vcf.db
+gemini query -q "select chrom, end, BaseQRankSum from variants" test.snpeff.vcf.db > obs
+
+echo "chr1	30548	0.0
+chr1	30860	2.815
+chr1	30869	0.9
+chr1	30895	-0.23
+chr1	30923	None
+chr1	69270	1.675
+chr1	69428	-0.638
+chr1	69511	-1.592
+chr1	69761	1.333
+chr1	69871	-0.646" > exp
+
+check obs exp test-annotate-vcf.t02
+
+
+
+gemini annotate -f test.anno.vcf.gz -o uniq_list -e BaseQRankSum -c MyBaseQRankSum -t float test.snpeff.vcf.db
+gemini query --header -q "select chrom, end, MyBaseQRankSum, BaseQRankSum from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	MyBaseQRankSum	BaseQRankSum
+chr1	30548	0.0	0.0
+chr1	30860	2.815	2.815
+chr1	30869	0.9	0.9
+chr1	30895	-0.23	-0.23
+chr1	30923	None	None
+chr1	69270	1.675	1.675
+chr1	69428	-0.638	-0.638
+chr1	69511	-1.592	-1.592
+chr1	69761	1.333	1.333
+chr1	69871	-0.646	-0.646" > exp
+
+check obs exp test-annotate-vcf.t03
+
+# check first
+
+gemini annotate -f test.anno.vcf.gz -o first -e BaseQRankSum -c MyBaseQRankSum -t float test.snpeff.vcf.db
+gemini query --header -q "select chrom, end, MyBaseQRankSum, BaseQRankSum from variants" test.snpeff.vcf.db > obs
+echo "chrom	end	MyBaseQRankSum	BaseQRankSum
+chr1	30548	0.0	0.0
+chr1	30860	2.815	2.815
+chr1	30869	0.9	0.9
+chr1	30895	-0.23	-0.23
+chr1	30923	None	None
+chr1	69270	1.675	1.675
+chr1	69428	-0.638	-0.638
+chr1	69511	-1.592	-1.592
+chr1	69761	1.333	1.333
+chr1	69871	-0.646	-0.646" > exp
+
+check obs exp test-annotate-vcf.t04
+
+####################################
+# create a missing record. and see -a boolean
+####################################
+zgrep -vw 69270 test.anno.vcf.gz | bgzip -c > t_.vcf.gz
+tabix t_.vcf.gz
+
+gemini annotate -f t_.vcf.gz -a boolean test.snpeff.vcf.db -c BaseQRankSum
+
+gemini query --header -q "select chrom, end, MyBaseQRankSum, BaseQRankSum from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	MyBaseQRankSum	BaseQRankSum
+chr1	30548	0.0	1.0
+chr1	30860	2.815	1.0
+chr1	30869	0.9	1.0
+chr1	30895	-0.23	1.0
+chr1	30923	None	1.0
+chr1	69270	1.675	0.0
+chr1	69428	-0.638	1.0
+chr1	69511	-1.592	1.0
+chr1	69761	1.333	1.0
+chr1	69871	-0.646	1.0" > exp
+
+check obs exp test-annotate-vcf.t05
+
+####################################
+# create a missing record. and see -a count
+####################################
+
+gemini annotate -f t_.vcf.gz -a count test.snpeff.vcf.db -c CountBaseQRankSum
+gemini query --header -q "select chrom, end, MyBaseQRankSum, BaseQRankSum, CountBaseQRankSum from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	MyBaseQRankSum	BaseQRankSum	CountBaseQRankSum
+chr1	30548	0.0	1.0	1
+chr1	30860	2.815	1.0	1
+chr1	30869	0.9	1.0	1
+chr1	30895	-0.23	1.0	1
+chr1	30923	None	1.0	1
+chr1	69270	1.675	0.0	0
+chr1	69428	-0.638	1.0	1
+chr1	69511	-1.592	1.0	1
+chr1	69761	1.333	1.0	1
+chr1	69871	-0.646	1.0	1" > exp
+
+check obs exp test-annotate-vcf.t06
+
+############################################
+# TODO: check mean, etc. with missing values.
+############################################
+
+gunzip t_.vcf.gz
+grep -w 69871 t_.vcf > t_
+cat t_ >> t_.vcf; rm t_
+bgzip -f t_.vcf
+tabix t_.vcf.gz
+
+gemini annotate -f t_.vcf.gz -o sum -e BaseQRankSum -c SumBaseQRankSum -t float test.snpeff.vcf.db
+gemini query --header -q "select chrom, end, BaseQRankSum, SumBaseQRankSum from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	BaseQRankSum	SumBaseQRankSum
+chr1	30548	1.0	None
+chr1	30860	1.0	2.815
+chr1	30869	1.0	0.9
+chr1	30895	1.0	-0.23
+chr1	30923	1.0	None
+chr1	69270	0.0	None
+chr1	69428	1.0	-0.638
+chr1	69511	1.0	-1.592
+chr1	69761	1.0	1.333
+chr1	69871	1.0	-1.292" > exp # note how the last number here is double of -0.646 becaus ewe included that last record twice.
+
+check obs exp test-annotate-vcf.t06
+
+
+gemini annotate -f t_.vcf.gz -a count test.snpeff.vcf.db -c CountBaseQRankSum
+gemini query --header -q "select chrom, end, CountBaseQRankSum from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	CountBaseQRankSum
+chr1	30548	1
+chr1	30860	1
+chr1	30869	1
+chr1	30895	1
+chr1	30923	1
+chr1	69270	0
+chr1	69428	1
+chr1	69511	1
+chr1	69761	1
+chr1	69871	2" > exp # note how the lat one has value of 2.
+
+check obs exp test-annotate-vcf.t07
+
+############################
+# Check Missing Values
+############################
+
+# add a 3rd value to the last row
+zless t_.vcf.gz > t2_.vcf
+grep -w 69871 t2_.vcf | perl -pe 's/BaseQRankSum=([^;]+);//' > t_
+cat t_ >> t2_.vcf; rm t_
+bgzip -f t2_.vcf
+tabix t2_.vcf.gz
+
+
+
+gemini annotate -f t2_.vcf.gz -t float -e BaseQRankSum -o mean test.snpeff.vcf.db -c Missing
+gemini query --header -q "select chrom, end, Missing from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	Missing
+chr1	30548	0
+chr1	30860	2.815
+chr1	30869	0.9
+chr1	30895	-0.23
+chr1	30923	None
+chr1	69270	None
+chr1	69428	-0.638
+chr1	69511	-1.592
+chr1	69761	1.333
+chr1	69871	-0.646" > exp
+
+check obs exp test-annotate-vcf.t08
+
+### NOTE!!!
+# that sum is 0 since np.sum([]) == 0 and mean is nan since np.mean([]) == nan
+###
+
+gemini annotate -f t2_.vcf.gz -t float -e BaseQRankSum -o sum test.snpeff.vcf.db -c Missing
+gemini query --header -q "select chrom, end, Missing from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	Missing
+chr1	30548	0
+chr1	30860	2.815
+chr1	30869	0.9
+chr1	30895	-0.23
+chr1	30923	0
+chr1	69270	None
+chr1	69428	-0.638
+chr1	69511	-1.592
+chr1	69761	1.333
+chr1	69871	-1.292" > exp
+
+check obs exp test-annotate-vcf.t09

--- a/test/test-annotate-tool-vcf.sh
+++ b/test/test-annotate-tool-vcf.sh
@@ -219,3 +219,21 @@ chr1	69761	1.333
 chr1	69871	-1.292" > exp
 
 check obs exp test-annotate-vcf.t09
+
+## test multiple columns
+gemini annotate -f test.anno.vcf.gz -t float,float -e AN,BaseQRankSum -o mean,list test.snpeff.vcf.db 
+gemini query --header -q "select chrom, end, AN,BaseQRankSum from variants" test.snpeff.vcf.db > obs
+
+echo "chrom	end	AN	BaseQRankSum
+chr1	30548	14.0	0.0
+chr1	30860	52.0	2.815
+chr1	30869	56.0	0.9
+chr1	30895	58.0	-0.23
+chr1	30923	30.0	None
+chr1	69270	56.0	1.675
+chr1	69428	106.0	-0.638
+chr1	69511	90.0	-1.592
+chr1	69761	88.0	1.333
+chr1	69871	80.0	-0.646" > exp
+
+check obs exp test-annotate-vcf.t10

--- a/test/test-annotate-tool-vcf.sh
+++ b/test/test-annotate-tool-vcf.sh
@@ -1,0 +1,26 @@
+###########################################################################################
+#Test annotating variants with a VCF.
+###########################################################################################
+source ./check.sh
+
+# make a dunnmy TABIX'ed annotation file
+#BaseQRankSum
+bgzip -c test.snpeff.vcf > test.anno.vcf.gz
+tabix test.anno.vcf.gz
+
+# create a new column in the database using the new annotation
+gemini annotate -f test.anno.vcf.gz -o uniq_list -c AN -t float test.snpeff.vcf.db
+
+gemini query -q "select chrom, end, AN from variants" test.snpeff.vcf.db > obs
+echo "chr1	30548	14.0
+chr1	30860	52.0
+chr1	30869	56.0
+chr1	30895	58.0
+chr1	30923	30.0
+chr1	69270	56.0
+chr1	69428	106.0
+chr1	69511	90.0
+chr1	69761	88.0
+chr1	69871	80.0" > exp
+
+check obs exp test-annotate-vcf.t01

--- a/test/test-annotate-tool.sh
+++ b/test/test-annotate-tool.sh
@@ -1,7 +1,7 @@
 ###########################################################################################
 #1. Test annotating variants using the "boolean" function
 ###########################################################################################
-echo "    annotate-tool.t1...\c"
+source ./check.sh
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548
@@ -25,7 +25,7 @@ chr1	69871	0" > exp
 
 gemini query -q "select chrom, end, anno from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t1
 rm obs exp
 rm *.gz*
 
@@ -33,7 +33,6 @@ rm *.gz*
 ###########################################################################################
 #2. Test annotating variants using the "count" function
 ###########################################################################################
-echo "    annotate-tool.t2...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548
@@ -58,7 +57,7 @@ chr1	69871	0" > exp
 
 gemini query -q "select chrom, end, anno2 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t2
 rm obs exp
 rm *.gz*
 
@@ -67,7 +66,6 @@ rm *.gz*
 #3. Test annotating variants using the "extract" function
 #   while extacting just one column
 ###########################################################################################
-echo "    annotate-tool.t3...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a
@@ -92,7 +90,7 @@ chr1	69871	None" > exp
 
 gemini query -q "select chrom, end, anno3 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t3
 rm obs exp
 rm *.gz*
 
@@ -100,7 +98,6 @@ rm *.gz*
 ###########################################################################################
 #4. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t4...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -125,7 +122,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno4, anno5 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t4
 rm obs exp
 rm *.gz*
 
@@ -133,7 +130,6 @@ rm *.gz*
 ###########################################################################################
 #5. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t5...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -159,7 +155,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno6, anno7 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t5
 rm obs exp
 rm *.gz*
 
@@ -167,7 +163,6 @@ rm *.gz*
 ###########################################################################################
 #6. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t6...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -193,7 +188,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno8, anno9 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t6
 rm obs exp
 rm *.gz*
 
@@ -201,7 +196,6 @@ rm *.gz*
 ###########################################################################################
 #7. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t7...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -227,7 +221,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno10, anno11 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t7
 rm obs exp
 rm *.gz*
 
@@ -260,14 +254,13 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno12, anno13 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t8
 rm obs exp
 rm *.gz*
 
 ###########################################################################################
 #9. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t9...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -293,7 +286,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno14, anno15 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t9
 rm obs exp
 rm *.gz*
 
@@ -301,7 +294,6 @@ rm *.gz*
 ###########################################################################################
 #10. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t10...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -327,7 +319,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno16, anno17 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annoate-tool.t10
 rm obs exp
 rm *.gz*
 
@@ -335,7 +327,6 @@ rm *.gz*
 ###########################################################################################
 #11. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t11...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -361,7 +352,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno18, anno19 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t11
 rm obs exp
 rm *.gz*
 
@@ -369,7 +360,6 @@ rm *.gz*
 ###########################################################################################
 #12. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t12...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -395,7 +385,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno20, anno21 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t12
 rm obs exp
 rm *.gz*
 
@@ -429,7 +419,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno22, anno23 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t13
 rm obs exp
 rm *.gz*
 
@@ -437,7 +427,6 @@ rm *.gz*
 ###########################################################################################
 #14. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t14...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -464,7 +453,7 @@ chr1	69871	None	None" > exp
 
 gemini query -q "select chrom, end, anno24, anno25 from variants" \
 	test.snpeff.vcf.db > obs
-check obs exp
+check obs exp annotate-tool.t14
 rm obs exp
 rm *.gz*
 
@@ -473,7 +462,6 @@ rm *.gz*
 ###########################################################################################
 #15. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t15...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -489,7 +477,7 @@ echo $'EXITING: The number of column names, numbers, types, and operations must 
 
 gemini annotate -f anno.bed.gz -a extract -c anno23 -e 4,5 -t text,float -o last,mode  test.snpeff.vcf.db 2> obs
 
-check obs exp
+check obs exp annotate-tool.t15
 rm obs exp
 rm *.gz*
 
@@ -497,7 +485,6 @@ rm *.gz*
 ##########################################################################################
 #16. Test annotating variants using the "extract" function
 ##########################################################################################
-echo "    annotate-tool.t16...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -517,7 +504,7 @@ gemini annotate: error: argument -a: invalid choice: 'distract' (choose from 'bo
 
 gemini annotate -f anno.bed.gz -a distract -c anno23,anno24 -e 4,5 -t text,float -o last,mode  test.snpeff.vcf.db 2> obs
 
-check obs exp
+check obs exp annotate-tool.t16
 rm obs exp
 rm *.gz*
 
@@ -525,7 +512,6 @@ rm *.gz*
 ###########################################################################################
 #17. Test annotating variants using the "extract" function
 ###########################################################################################
-echo "    annotate-tool.t17...\c"
 
 # make a dunnmy TABIX'ed annotation file
 echo "chr1	30547	30548	a	0.23
@@ -541,6 +527,6 @@ echo $'EXITING: Column operation [model] not supported.\n' > exp
 
 gemini annotate -f anno.bed.gz -a extract -c anno27,anno28 -e 4,5 -t text,float -o last,model  test.snpeff.vcf.db 2> obs
 
-check obs exp
+check obs exp annotate-tool.t17
 #rm obs exp
 rm *.gz*


### PR DESCRIPTION
this is in progress, but opened for discussion. Tests are pretty solid. I am working on docs. It allows a user to annotate with a vcf like:

     gemini annotate -f $VCF -t float -e BaseQRankSum -o mean $DB

where BaseQRankSum is pulled from the info field. Missing values (e.g. from a VCF record without that INFO field) are allowed.