### PR TITLE
improve load performance

### DIFF
--- a/gemini/annotation_provenance/make-fitcons.sh
+++ b/gemini/annotation_provenance/make-fitcons.sh
@@ -1,0 +1,4 @@
+PRE=hg19_fitcons_fc-i6-0_V1-01
+bigWigToBedGraph ${PRE}.bw ${PRE}.bed
+bgzip ${PRE}.bed
+tabix ${PRE}.bed.gz

--- a/gemini/annotations.py
+++ b/gemini/annotations.py
@@ -194,18 +194,17 @@ def load_annos( args ):
 # ## Standard access to Tabix indexed files
 
 
-def _get_hits(coords, annotation, parser_type):
+PARSERS = {"bed": pysam.asBed(),
+           "vcf": pysam.asVCF(),
+           "tuple": pysam.asTuple(),
+           None: None}
+
+def _get_hits(coords, annotation, parser_type, _parsers=PARSERS):
     """Retrieve BED information, recovering if BED annotation file does have a chromosome.
     """
-    if parser_type == "bed":
-        parser = pysam.asBed()
-    elif parser_type == "vcf":
-        parser = pysam.asVCF()
-    elif parser_type == "tuple":
-        parser = pysam.asTuple()
-    elif parser_type is None:
-        parser = None
-    else:
+    try:
+        parser = _parsers[parser_type]
+    except KeyError:
         raise ValueError("Unexpected parser type: %s" % parser)
     chrom, start, end = coords
     try:

--- a/gemini/install-data.py
+++ b/gemini/install-data.py
@@ -50,7 +50,7 @@ anno_files = \
 'detailed_gene_table_v75',
 'summary_gene_table_v75',
 'cancer_gene_census.20140120.tsv',
-'hg19_fitcons_fc-i6-0_V1-01.bw',
+'hg19_fitcons_fc-i6-0_V1-01.bed.gz',
 'ExAC.r0.3.sites.vep.tidy.vcf.gz'
 ]
 extra_anno_files = {"gerp_bp": "hg19.gerp.bw", "cadd_score": "whole_genome_SNVs.tsv.compressed.gz"}

--- a/master-test.sh
+++ b/master-test.sh
@@ -86,6 +86,8 @@ bash test-stats.sh
 # Test windower
 bash test-windower.sh
 
+#
+bash test-fitcons.sh
 
 # Test pfam domains
 bash test-pfam.sh

--- a/test/test-fitcons.sh
+++ b/test/test-fitcons.sh
@@ -1,0 +1,60 @@
+#############################################
+# 1. Test ExAC allele frequencies
+#############################################
+source ./check.sh
+
+gemini query -q "select fitcons from variants" test.exac.db > obs
+
+echo "0.706548
+0.088506
+0.646311
+0.455138
+0.053691
+0.615465
+0.497415
+0.706548" > exp
+
+check obs exp fitcons.t01
+rm obs exp
+
+
+#############################################
+
+gemini query -q "select fitcons from variants" test.amend.db  > obs
+echo "0.156188
+0.553676
+0.061011
+0.080785
+0.722319
+0.069865
+0.056701
+0.487112
+0.732398" > exp
+
+check obs exp fitcons.t02
+rm obs exp
+
+
+#############################################
+
+
+gemini query -q "select fitcons from variants" test.query.vep.db | awk '(NR % 50 == 0)'  > obs
+echo "0.095506
+0.099367
+0.121938
+0.088506
+0.166803
+0.118714
+0.078448
+0.156188
+0.055982
+0.056701
+0.056701
+0.114469
+0.069865
+0.283894
+None
+0.078448
+None" > exp
+
+check obs exp fitcons.t03


### PR DESCRIPTION
Work in progress...

On master, the load-time is dominated by stuff related to bigwig (even without GERP). For loading about 10K records on a slow laptop we get:

```
         201859321 function calls (201853743 primitive calls) in 816.745 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 48414395  229.792    0.000  371.800    0.000 binary_file.py:51(read_and_unpack)
 32591931   96.148    0.000  346.071    0.000 binary_file.py:98(read_uint32)
     9865   87.024    0.009  603.337    0.061 {method 'summarize' of 'bx.bbi.bbi_file.BBIFile' objects}
 48444676   68.272    0.000   68.272    0.000 {_struct.unpack}
        6   52.071    8.679   52.071    8.679 {method 'executemany' of 'sqlite3.Cursor' objects}
 30372230   43.242    0.000   43.242    0.000 {method 'read' of 'cStringIO.StringI' objects}
 18086005   30.800    0.000   30.800    0.000 {method 'read' of 'file' objects}
 10100736   29.896    0.000  106.517    0.000 binary_file.py:104(read_float)
     9865   23.537    0.002   24.426    0.002 annotations.py:639(get_exac_info)
  5613211   16.796    0.000   61.063    0.000 binary_file.py:101(read_uint64)
       78   14.811    0.190   14.811    0.190 {method 'execute' of 'sqlite3.Cursor' objects}
        1    9.812    9.812   24.710   24.710 gemini_load_chunk.py:583(_get_gene_detailed)
     9865    7.046    0.001    7.618    0.001 annotations.py:613(get_1000G_info)
     9865    6.019    0.001    6.475    0.001 annotations.py:784(get_recomb_info)
     9865    5.607    0.001    6.056    0.001 annotations.py:546(get_dbsnp_info)
```

With the changes in the first commit here, to use bed.gz and tabix instead of bigwig, this goes to:

```
         7955140 function calls (7949562 primitive calls) in 274.318 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     9865   60.558    0.006   60.968    0.006 annotations.py:390(get_fitcons)
        6   53.082    8.847   53.082    8.847 {method 'executemany' of 'sqlite3.Cursor' objects}
     9865   22.795    0.002   23.404    0.002 annotations.py:635(get_exac_info)
       78   14.932    0.191   14.932    0.191 {method 'execute' of 'sqlite3.Cursor' objects}
        1    9.952    9.952   25.312   25.312 gemini_load_chunk.py:583(_get_gene_detailed)
     9865    7.178    0.001    7.750    0.001 annotations.py:609(get_1000G_info)
     9865    5.979    0.001    6.426    0.001 annotations.py:780(get_recomb_info)
     9865    5.831    0.001    6.279    0.001 annotations.py:542(get_dbsnp_info)
     9865    5.055    0.001    5.070    0.001 annotations.py:796(_get_first_vcf_hit)
     9865    5.051    0.001    5.550    0.001 annotations.py:876(get_encode_consensus_segs)
     9865    4.950    0.001    5.397    0.001 annotations.py:367(get_gerp_elements)
     9865    4.500    0.000    4.942    0.001 annotations.py:740(get_rmsk_info)
     9865    4.339    0.000    4.801    0.000 annotations.py:838(get_encode_tfbs)
     9865    4.332    0.000    4.728    0.000 annotations.py:761(get_conservation_info)
     9865    4.274    0.000    4.651    0.000 annotations.py:831(get_cse)
```

So, **274** seconds instead of **817**. This should be a general speed improvement for all loads on the order of 3X. 
