### PR TITLE
Add -classic instruction to normalize/annotate workflow in index.rst

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,11 +32,12 @@ A workflow for the above steps is given below.
 
   # decompose, normalize and annotate VCF with snpEff.
   # NOTE: can also swap snpEff with VEP
-  zless $VCF \
+  #NOTE: -classic and -formatEff flags needed with snpEff >= v4.1
+zless $VCF \
      | sed 's/ID=AD,Number=./ID=AD,Number=R/'
      | vt decompose -s - \
      | vt normalize -r $REF - \
-     | java -Xmx4G -jar $SNPEFFJAR -formatEff GRCh37.75  \
+     | java -Xmx4G -jar $SNPEFFJAR -formatEff -classic GRCh37.75  \
      | bgzip -c > $NORMVCF
   tabix $NORMVCF
 


### PR DESCRIPTION
I added the -classic flag and explanation to the workflow presented at the top of the index page in the documentation as it was missing.