### PR TITLE
Make GEMINI able to use a config file location from the environment.

### DIFF
--- a/gemini/config.py
+++ b/gemini/config.py
@@ -13,6 +13,7 @@ import os
 import yaml
 
 CONFIG_FILE = "gemini-config.yaml"
+CONFIG_ENVIRONMENT_VARIABLE = "GEMINI_CONFIG"
 
 def get_config_dirs(use_globals=True):
     virtualenv_loc = __file__.find("gemini-virtualenv")
@@ -26,6 +27,9 @@ def get_config_dirs(use_globals=True):
     else:
         dirs = []
     if use_globals:
+        environment_config = os.getenv(CONFIG_ENVIRONMENT_VARIABLE)
+        if environment_config is not None:
+            dirs.append(environment_config)
         dirs.append("/usr/local/share/gemini")
         dirs.append(os.path.join(os.environ["HOME"], ".gemini"))
     return dirs


### PR DESCRIPTION
This can come in pretty handy when installing GEMINI on a multi-user, multi-machine system (e.g. a compute cluster).
It would be necessary to put a config file in every user homedir or onto every machine into /usr/local/.
With this patch we specify a default location, which the user can then override if necessary.

Let me know what you think about that.
