### PR TITLE
Add --index option to gemini merge_chunks

### DIFF
--- a/gemini/gemini_main.py
+++ b/gemini/gemini_main.py
@@ -162,7 +162,7 @@ def main():
                              default=None, help='Cluster queue to use.')
     parser_load.add_argument('--tempdir', dest='tempdir',
                              default=tempfile.gettempdir(),
-                             help="temp directory to use when loading with multiple cores")
+                             help='Temp directory for storing intermediate files when loading in parallel.')
     parser_load.add_argument('--passonly',
                              dest='passonly',
                              default=False,
@@ -265,7 +265,8 @@ def main():
                          default=False)
     parser_loadchunk.add_argument('--tempdir', dest='tempdir',
                                   default=tempfile.gettempdir(),
-                                  help='temporary dir for loading')
+                                  help='Local (non-NFS) temp directory to use for working around SQLite locking issues '
+                                       'on NFS drives.')
 
     def loadchunk_fn(parser, args):
         import gemini_load_chunk
@@ -285,7 +286,12 @@ def main():
             dest='chunkdbs',
             action='append')
     parser_mergechunks.add_argument('--tempdir', dest='tempdir',
-            default=tempfile.gettempdir(), help='<TODO add help>')
+            default=tempfile.gettempdir(),
+            help='Local (non-NFS) temp directory to use for working around SQLite locking issues on NFS drives.')
+    parser_mergechunks.add_argument('--index', dest='index',
+            action='store_true',
+            help='Create all database indexes. If multiple merges are used to create a database, only the last merge '
+                 'should create the indexes.')
 
     def mergechunk_fn(parser, args):
         import gemini_merge_chunks

--- a/gemini/gemini_merge_chunks.py
+++ b/gemini/gemini_merge_chunks.py
@@ -201,6 +201,9 @@ def merge_db_chunks(args):
         else:
             update_sample_genotype_counts(main_curr, db)
 
+    if args.index:
+        gemini_db.create_indices(main_curr)
+
     main_conn.commit()
     main_curr.close()
 


### PR DESCRIPTION
Add option to create all db indexes at the end of merge_chunks - for pipelines that call merge_chunks outside of gemini load. Also, add CLI help messages for --tempdir.