### PR TITLE
add max_aaf_all column.

### DIFF
--- a/docs/content/database_schema.rst
+++ b/docs/content/database_schema.rst
@@ -164,6 +164,7 @@ aaf_adj_exac_fin          FLOAT         Adjusted allele frequency of the variant
 aaf_adj_exac_nfe          FLOAT         Adjusted allele frequency of the variant for NFE population in ExAC (AC_NFE/AN_NFE)
 aaf_adj_exac_oth          FLOAT         Adjusted allele frequency of the variant for OTH population in ExAC (AC_OTH/AN_OTH)
 aaf_adj_exac_sas          FLOAT         Adjusted allele frequency of the variant for SAS population in ExAC (AC_SAS/AN_SAS)
+max_aaf_all               FLOAT         the maximum of aaf_esp_ea, aaf_esp_aa, aaf_1kg_amr, aaf_1kg_eas,aaf_1kg_sas,aaf_1kg_afr,aaf_1kg_eur,aaf_adj_exac_afr,aaf_adj_exac_amr,aaf_adj_exac_eas,aaf_adj_exac_nfe,aaf_adj_exac_sas. and -1 if none of those databases/populations contain the variant.
 ========================  =========     =================================================================================================
 
 

--- a/docs/content/history.rst
+++ b/docs/content/history.rst
@@ -14,6 +14,7 @@ Release History
 #. switch to cyvcf2 to speed loading
 #. per-sample depths are calculated using AD (GATK) or AO+RO (Freebayes). This makes depth filters more conservative.
 #. extra VEP annotations are loaded with loading machinery, not as an extra step as before.
+#. add max_aaf_all column (https://github.com/arq5x/gemini/issues/520) as an aggregate of a number of population filters
 
 
 0.16.3

--- a/gemini/database.py
+++ b/gemini/database.py
@@ -40,6 +40,7 @@ def index_variation(cursor):
     cursor.execute('''create index var_fitcons_idx on variants(fitcons)''')
     cursor.execute('''create index var_sv_event_idx on variants(sv_event_id)''')
     cursor.execute('''create index chrom_varid_idx on variants(chrom,variant_id)''')
+    cursor.execute('CREATE index max_aaf_all_idx on variants(max_aaf_all)')
 
 def index_variation_impacts(cursor):
     cursor.execute('''create index varimp_exonic_idx on \
@@ -86,6 +87,14 @@ def create_indices(cursor):
     index_gene_detailed(cursor)
     index_gene_summary(cursor)
 
+def add_max_aaf(cursor):
+    # see: https://github.com/arq5x/gemini/issues/520
+    # skip finns
+    cursor.execute('ALTER TABLE variants ADD COLUMN max_aaf_all')
+    cursor.execute('''UPDATE variants set max_aaf_all = MAX(aaf_esp_ea, aaf_esp_aa, aaf_1kg_amr, aaf_1kg_eas, \
+                   aaf_1kg_sas,aaf_1kg_afr,aaf_1kg_eur,aaf_adj_exac_afr,aaf_adj_exac_amr,aaf_adj_exac_eas, \
+                aaf_adj_exac_nfe,aaf_adj_exac_sas)''')
+    cursor.execute('UPDATE variants set max_aaf_all = -1 WHERE max_aaf_all is NULL')
 
 def create_tables(cursor, effect_fields=None):
     """

--- a/gemini/gemini_load.py
+++ b/gemini/gemini_load.py
@@ -63,6 +63,7 @@ def load_singlecore(args):
     gemini_loader.store_version()
     gemini_loader.store_vcf_header()
     gemini_loader.populate_from_vcf()
+    gemini_db.add_max_aaf(gemini_loader.c)
 
     if not args.skip_gene_tables and not args.test_mode:
         gemini_loader.update_gene_table()
@@ -102,6 +103,7 @@ def get_merge_chunks_cmd(chunks, db, tempdir=None):
 
     return "gemini merge_chunks {chunk_names} {tempdir_string} --db {db}".format(**locals())
 
+
 def finalize_merged_db(tmp_db, db):
     ts = time.time()
     st = datetime.datetime.fromtimestamp(ts).strftime('%Y-%m-%d %H:%M:%S')
@@ -113,6 +115,7 @@ def finalize_merged_db(tmp_db, db):
     main_curr.execute('PRAGMA synchronous = OFF')
     main_curr.execute('PRAGMA journal_mode=MEMORY')
 
+    gemini_db.add_max_aaf(main_curr)
     gemini_db.create_indices(main_curr)
 
     main_conn.commit()

--- a/test/test-query.sh
+++ b/test/test-query.sh
@@ -768,13 +768,20 @@ gemini query --header --format sampledetail --show-samples -q "select chrom, sta
 check obs exp
 rm obs exp
 
+echo "    query.t42...\c"
+echo "-1	None	None	None	None	None	None	None	0	0	0	0	0
+-1	None	None	None	None	None	None	None	None	None	None	None	None
+-1	None	None	None	None	None	None	None	None	None	None	None	None
+-1	None	None	None	None	None	None	None	None	None	None	None	None
+-1	None	None	0.9164	0.996	0.9233	0.6687	0.9364	None	None	None	None	None
+-1	None	None	None	None	None	None	None	0.292253521127	0.631578947368	0.98275862069	0.833928571429	0.866379310345
+0.0497	0.0457067757009	0.003663003663	0.036	0.003	0.0153	0.0015	0.0497	0.00255297421496	0.00804493017608	0	0.0405799922149	0.00488782051282
+-1	0.88742933156	0.544101123596	None	None	None	None	None	0.594155844156	0.950725980846	0.999403625954	0.971647095179	0.983191249799
+0.280445372303	0.136133389616	0.0213645761544	0.0418	0.001	0.045	0.0045	0.1034	0.0217391304348	0.118834080717	0	0.280445372303	0.154037886341
+-1	None	None	None	None	None	None	None	0	0	0	0	0" > exp
+gemini query -q "select max_aaf_all,aaf_esp_ea, aaf_esp_aa, aaf_1kg_amr, aaf_1kg_eas, \
+                 aaf_1kg_sas,aaf_1kg_afr,aaf_1kg_eur,aaf_adj_exac_afr,aaf_adj_exac_amr,aaf_adj_exac_eas, \
+                 aaf_adj_exac_nfe,aaf_adj_exac_sas from variants limit 10" test.query.db > obs
 
-
-
-
-
-
-
-
-
- 
+check obs exp
+rm obs exp


### PR DESCRIPTION
This is to address #520

When none of the values are present in any population it sets the value to -1 in this column so that:

```
max_aaf_all < 0.005
```

replaces (note that I excluded the fin column).

```
(aaf_esp_ea <= 0.005 or aaf_esp_ea is NULL) AND \
(aaf_esp_aa <= 0.005 or aaf_esp_aa is NULL) AND \
(aaf_1kg_amr <= 0.005 or aaf_1kg_amr is NULL) AND \
(aaf_1kg_eas <= 0.005 or aaf_1kg_eas is NULL) AND \
(aaf_1kg_sas <= 0.005 or aaf_1kg_sas is NULL) AND \
(aaf_1kg_afr <= 0.005 or aaf_1kg_afr is NULL) AND \
(aaf_1kg_eur <= 0.005 or aaf_1kg_eur is NULL) AND \
(aaf_adj_exac_afr <= 0.005 or aaf_adj_exac_afr is NULL) AND \
(aaf_adj_exac_amr <= 0.005 or aaf_adj_exac_amr is NULL) AND \
(aaf_adj_exac_eas <= 0.005 or aaf_adj_exac_eas is NULL) AND \
(aaf_adj_exac_nfe <= 0.005 or aaf_adj_exac_nfe is NULL) AND \
(aaf_adj_exac_sas <= 0.005 or aaf_adj_exac_sas is NULL)
```
