### PR TITLE
fix max_aaf_all calculation using coalesce. previously, if any

### DIFF
--- a/gemini/database.py
+++ b/gemini/database.py
@@ -91,10 +91,7 @@ def add_max_aaf(cursor):
     # see: https://github.com/arq5x/gemini/issues/520
     # skip finns
     cursor.execute('ALTER TABLE variants ADD COLUMN max_aaf_all')
-    cursor.execute('''UPDATE variants set max_aaf_all = MAX(aaf_esp_ea, aaf_esp_aa, aaf_1kg_amr, aaf_1kg_eas, \
-                   aaf_1kg_sas,aaf_1kg_afr,aaf_1kg_eur,aaf_adj_exac_afr,aaf_adj_exac_amr,aaf_adj_exac_eas, \
-                aaf_adj_exac_nfe,aaf_adj_exac_sas)''')
-    cursor.execute('UPDATE variants set max_aaf_all = -1 WHERE max_aaf_all is NULL')
+    cursor.execute('UPDATE variants set max_aaf_all = MAX(coalesce(aaf_esp_ea,-1), coalesce(aaf_esp_aa,-1), coalesce(aaf_1kg_amr,-1), coalesce(aaf_1kg_eas,-1), coalesce(aaf_1kg_sas,-1), coalesce(aaf_1kg_afr,-1), coalesce(aaf_1kg_eur,-1), coalesce(aaf_adj_exac_afr,-1), coalesce(aaf_adj_exac_amr,-1), coalesce(aaf_adj_exac_eas,-1), coalesce(aaf_adj_exac_nfe,-1), coalesce(aaf_adj_exac_sas,-1))')
 
 def create_tables(cursor, effect_fields=None):
     """

--- a/test/test-query.sh
+++ b/test/test-query.sh
@@ -769,16 +769,16 @@ check obs exp
 rm obs exp
 
 echo "    query.t42...\c"
-echo "-1	None	None	None	None	None	None	None	0	0	0	0	0
+echo "0	None	None	None	None	None	None	None	0	0	0	0	0
 -1	None	None	None	None	None	None	None	None	None	None	None	None
 -1	None	None	None	None	None	None	None	None	None	None	None	None
 -1	None	None	None	None	None	None	None	None	None	None	None	None
--1	None	None	0.9164	0.996	0.9233	0.6687	0.9364	None	None	None	None	None
--1	None	None	None	None	None	None	None	0.292253521127	0.631578947368	0.98275862069	0.833928571429	0.866379310345
+0.996	None	None	0.9164	0.996	0.9233	0.6687	0.9364	None	None	None	None	None
+0.98275862069	None	None	None	None	None	None	None	0.292253521127	0.631578947368	0.98275862069	0.833928571429	0.866379310345
 0.0497	0.0457067757009	0.003663003663	0.036	0.003	0.0153	0.0015	0.0497	0.00255297421496	0.00804493017608	0	0.0405799922149	0.00488782051282
--1	0.88742933156	0.544101123596	None	None	None	None	None	0.594155844156	0.950725980846	0.999403625954	0.971647095179	0.983191249799
+0.999403625954	0.88742933156	0.544101123596	None	None	None	None	None	0.594155844156	0.950725980846	0.999403625954	0.971647095179	0.983191249799
 0.280445372303	0.136133389616	0.0213645761544	0.0418	0.001	0.045	0.0045	0.1034	0.0217391304348	0.118834080717	0	0.280445372303	0.154037886341
--1	None	None	None	None	None	None	None	0	0	0	0	0" > exp
+0	None	None	None	None	None	None	None	0	0	0	0	0" > exp
 gemini query -q "select max_aaf_all,aaf_esp_ea, aaf_esp_aa, aaf_1kg_amr, aaf_1kg_eas, \
                  aaf_1kg_sas,aaf_1kg_afr,aaf_1kg_eur,aaf_adj_exac_afr,aaf_adj_exac_amr,aaf_adj_exac_eas, \
                  aaf_adj_exac_nfe,aaf_adj_exac_sas from variants limit 10" test.query.db > obs


### PR DESCRIPTION
population was missing the variant, it would be set to -1 due to the way
that MAX works in sqlite