### PR TITLE
support snpEff names that contain multiple terms separated by "+"

### DIFF
--- a/gemini/func_impact.py
+++ b/gemini/func_impact.py
@@ -41,13 +41,13 @@ def interpret_impact(args, var, effect_fields):
                 impact_detail = piece[1]
                     # all the other information, which is inside the ()
                 try:
-                    impact_info = snpEff.effect_map[impact_string]
+                    impact_info = snpEff.recognized_effects(impact_string)[0]
                     impact_details = snpEff.EffectDetails(impact_string,
                                                       impact_info.priority,
                                                       impact_detail,
                                                       counter,
                                                       args.maj_version)
-                except KeyError:
+                except IndexError:
                     impact_details = snpEff.EffectDetails(impact_string,
                                                     None,
                                                     impact_detail,

--- a/gemini/severe_impact.py
+++ b/gemini/severe_impact.py
@@ -45,7 +45,7 @@ def interpret_severe_impact(args, var, effect_fields):
                 impact_detail = piece[1]
                     
                 try:
-                    impact_info = snpEff.effect_map[impact_string]
+                    impact_info = snpEff.recognized_effects(impact_string)[0]
                     # update the impact stored if a higher or an equal severity transcript
                     # is encountered
                     if impact_info.priority_code <= max_severity:
@@ -59,7 +59,7 @@ def interpret_severe_impact(args, var, effect_fields):
                         max_severity = impact_info.priority_code 
                         # This would store the highest priority for the next outer loop
                         top_severity =  impact_info.priority
-                except KeyError:
+                except IndexError:
                     pass
                     
         # prioritizing biotype: initialize flags to a high value

--- a/gemini/snpEff.py
+++ b/gemini/snpEff.py
@@ -82,8 +82,8 @@ class EffectDetails(object):
         self.polyphen_score = None
         self.sift_pred = None
         self.sift_score = None
-        self.consequence = effect_dict[self.effect_name] if self.effect_severity != None else self.effect_name
-        self.so = effect_so[self.effect_name] if self.effect_severity != None else self.effect_name
+        self.consequence = '+'.join([effect_dict[name] for name in self.effect_name.split('+')]) if self.effect_severity != None else self.effect_name
+        self.so = '+'.join([effect_so[name] for name in self.effect_name.split('+')]) if self.effect_severity != None else self.effect_name
 
     def __str__(self):
         return "\t".join([self.consequence, self.effect_severity,
@@ -382,12 +382,17 @@ eff_pattern = '(\S+)[(](\S+)[)]'
 eff_search = re.compile(eff_pattern)
 
 
+def recognized_effects(effect_key):
+    return sorted([effect_map[x] for x in effect_key.split('+') if x in effect_map],
+            key=lambda x: x.priority_code)
+
+
 def gatk_effect_details(info):
     """Convert GATK prepared snpEff effect details into standard EffectDetails.
     """
     name = info.get("SNPEFF_EFFECT", None)
     if name is not None:
-        effect = effect_map[name]
+        effect = recognized_effects(name)[0]
         detail_string = "|{impact}|{codon_change}|{aa_change}|{gene}|{biotype}|{coding}|{transcript}|{exon}".format(
             impact=info.get("SNPEFF_IMPACT", ""),
             codon_change=info.get("SNPEFF_CODON_CHANGE", ""),

--- a/test/test-eff.sh
+++ b/test/test-eff.sh
@@ -1,6 +1,6 @@
 echo "test.eff-plus.t1"
-echo "chrom	start	end	gene	ref	alt	aa_change	is_coding	is_exonic
-chr6	34950530	34950531	ANKS1A	G	A	T245	1	1" > exp
-gemini query --header -q "select chrom,start,end,gene,ref,alt,aa_change,is_coding,is_exonic from variants" test.eff.db > obs
+echo "chrom	start	end	gene	ref	alt	aa_change	is_coding	is_exonic	impact_severity
+chr6	34950530	34950531	ANKS1A	G	A	T245	1	1	MED" > exp
+gemini query --header -q "select chrom,start,end,gene,ref,alt,aa_change,is_coding,is_exonic,impact_severity from variants" test.eff.db > obs
 
 check obs exp


### PR DESCRIPTION
This may not be the perfect way to address #415 (the better way is #442), but it can be considered food for thought...

I was frustrated with having to use snpeff 3.6 (a couple of years old now!) to keep from missing splice site mutations, so I coded this up to split the impact_string by its `+` delimiters, sort the effects by lowest priority_code, and take the code of the 0th value. `consequence` and `so` still store `+` delimited versions, so the info from snpEff is not lost.

This may tide things over until settling in to ANN as per #442 (which should theoretically result in code reduction since VEP, snpEff, and Annovar all have plans to support ANN (hopefully in a not-too-incompatible way)