### PR TITLE
additional options to snpEff setup

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -107,12 +107,13 @@ A workflow for the above steps is given below.
 
   # decompose, normalize and annotate VCF with snpEff.
   # NOTE: can also swap snpEff with VEP
-  #NOTE: -classic and -formatEff flags needed with snpEff >= v4.1
+  # NOTE: -classic and -formatEff flags needed with snpEff >= v4.1
+  # NOTE: geneimpacts module does not currently handle annotations provided by nextprot or motif
   zless $VCF \
      | sed 's/ID=AD,Number=./ID=AD,Number=R/' \
      | vt decompose -s - \
      | vt normalize -r $REF - \
-     | java -Xmx4G -jar $SNPEFFJAR GRCh37.75 -formatEff -classic \
+     | java -Xmx4G -jar $SNPEFFJAR GRCh37.75 -formatEff -classic -noNextProt -noMotif \
      | bgzip -c > $NORMVCF
   tabix -p vcf $NORMVCF
 


### PR DESCRIPTION
The geneimpacts module exits with an error when snpEff NextProt or Motif annotations are present in the VCF file, so update the instructions to prevent these fields from being added by snpEff.

This could alternatively be fixed by updating geneimpacts, but for now it seems best to allow people to directly run code from the examples in the instructions without errors.