### PR TITLE
document the --max-priority option

### DIFF
--- a/docs/content/tools.rst
+++ b/docs/content/tools.rst
@@ -163,7 +163,7 @@ Genotype Requirements
 - Remove candidates where an affected from the same family does NOT share the same het pair.
 - Sites are automatically phased by transmission when parents are present in order to remove false positive candidates.
   
-  a. If parental genotypes are unavailable, all comp_het variant pairs will automatically be given priority == 2
+  a. If data from one or both parents are unavailable and the child's data was not phased prior to loading into GEMINI, all comp_het variant pairs will automatically be given priority == 2
   
   b. `--max-priority x` can be used to set the maximum allowed priority level at which candidate pairs are included in the output.
 

--- a/docs/content/tools.rst
+++ b/docs/content/tools.rst
@@ -162,6 +162,11 @@ Genotype Requirements
 
 - Remove candidates where an affected from the same family does NOT share the same het pair.
 - Sites are automatically phased by transmission when parents are present in order to remove false positive candidates.
+  
+  a. If parental genotypes are unavailable, all comp_het variant pairs will automatically be given priority == 2
+  
+  b. `--max-priority x` can be used to set the maximum allowed priority level at which candidate pairs are included in the output.
+
 
 we prioritize with these rules:
 


### PR DESCRIPTION
and that if parental genotypes are unavailable, results will be priority == 2

@brentp - what happens if one and only one parent was sequenced in addition to the proband?

(also sorry if I messed this up, I just switched to Sourcetree and never done a pull request before)