### PR TITLE
fix bug that causes multiple tags to match current version

### DIFF
--- a/gemini/gemini_update.py
+++ b/gemini/gemini_update.py
@@ -78,7 +78,7 @@ def _update_testdir_revision(gemini_cmd):
     tag = ""
     if gversion:
         try:
-            p = subprocess.Popen("git tag -l | grep %s" % gversion, stdout=subprocess.PIPE, shell=True)
+            p = subprocess.Popen("git tag -l | grep %s$" % gversion, stdout=subprocess.PIPE, shell=True)
             tag = p.communicate()[0].strip()
         except:
             tag = ""


### PR DESCRIPTION
Hi, 

I'm installing a local copy using `` and it fails with this: 

```

Gemini data files updated
From https://github.com/arq5x/gemini
 * branch            master     -> FETCH_HEAD
Already up-to-date.
error: pathspec 'tags/v0.18.0
v0.18.0a' did not match any file(s) known to git.
Traceback (most recent call last):
  File "/home/daniel.klevebring/gemini/anaconda/bin/gemini", line 6, in <module>
    gemini.gemini_main.main()
  File "/home/daniel.klevebring/gemini/anaconda/lib/python2.7/site-packages/gemini/gemini_main.py", line 1179, in main
    args.func(parser, args)
  File "/home/daniel.klevebring/gemini/anaconda/lib/python2.7/site-packages/gemini/gemini_main.py", line 1021, in update_fn
    gemini_update.release(parser, args)
  File "/home/daniel.klevebring/gemini/anaconda/lib/python2.7/site-packages/gemini/gemini_update.py", line 42, in release
    _update_testbase(test_dir, repo, gemini_cmd)
  File "/home/daniel.klevebring/gemini/anaconda/lib/python2.7/site-packages/gemini/gemini_update.py", line 67, in _update_testbase
    _update_testdir_revision(gemini_cmd)
  File "/home/daniel.klevebring/gemini/anaconda/lib/python2.7/site-packages/gemini/gemini_update.py", line 86, in _update_testdir_revision
    subprocess.check_call(["git", "checkout", "tags/%s" % tag])
  File "/home/daniel.klevebring/gemini/anaconda/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['git', 'checkout', 'tags/v0.18.0\nv0.18.0a']' returned non-zero exit status 1
Traceback (most recent call last):
  File "./gemini/scripts/gemini_install.py", line 184, in <module>
    main(parser.parse_args())
  File "./gemini/scripts/gemini_install.py", line 81, in main
    install_rest(gemini, args)
  File "./gemini/scripts/gemini_install.py", line 142, in install_rest
    subprocess.check_call(cmd)
  File "/home/daniel.klevebring/.pyenv/versions/2.7.8/lib/python2.7/subprocess.py", line 540, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/daniel.klevebring/gemini/anaconda/bin/gemini', 'update', '--dataonly', '--annotationdir', '/home/daniel.klevebring/gemini/gemini_data', '--tooldir', '/home/daniel.klevebring/gemini']' returned non-zero exit status 1

```

the reason for the error is a grep that matches multiple tags. This tiny PR fixes that bug by making the grep require the line to end after the version string. 