### PR TITLE
dont use order by for tools when min-kindreds is 1 or None or --families

### DIFF
--- a/gemini/gim.py
+++ b/gemini/gim.py
@@ -16,7 +16,7 @@ from inheritance import Family
 
 class GeminiInheritanceModel(object):
 
-    required_columns = ("family_id", "family_members",
+    required_columns = ("gene", "family_id", "family_members",
                         "family_genotypes", "samples", "family_count")
 
     def __init__(self, args):
@@ -41,7 +41,7 @@ class GeminiInheritanceModel(object):
             query = "SELECT chrom, start, end, * %s " \
                 + "FROM variants" % ", ".join(self.gt_cols)
 
-        query = sql_utils.ensure_columns(query, ['variant_id'])
+        query = sql_utils.ensure_columns(query, ['variant_id', 'gene'])
         # add any non-genotype column limits to the where clause
         if self.args.filter:
             query += " WHERE " + self.args.filter
@@ -52,11 +52,18 @@ class GeminiInheritanceModel(object):
            (self.model == "de_novo" and self.args.min_kindreds is not None):
 
             # we require the "gene" column for the auto_* tools
-            query = sql_utils.ensure_columns(query, ['gene'])
             if self.args.filter:
-                query += " AND gene is not NULL ORDER BY chrom, gene"
+                query += " AND gene is not NULL"
             else:
-                query += " WHERE gene is not NULL ORDER BY chrom, gene"
+                query += " WHERE gene is not NULL"
+
+        # only need to order by gene for comp_het and when min_kindreds is used.
+        if self.model == "comp_het" or not (
+                self.args.min_kindreds in (None, 1)
+                and (self.args.families is None
+                     or not "," in self.args.families)):
+            query += " ORDER by chrom, gene"
+
         return query
 
     def bcolz_candidates(self):

--- a/test/test-auto-dom.sh
+++ b/test/test-auto-dom.sh
@@ -13,14 +13,14 @@ export -f check
 ###################################################################
 echo "    auto_dom.t1...\c"
 echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
+WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
-SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
-WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2" > exp
+SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1" > exp
 
 gemini autosomal_dominant  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
@@ -96,14 +96,14 @@ echo "    auto_dom.t6...\c"
 
 echo "WARNING: using affected without parents for family 2 for autosomal dominant test. Use strict to prevent this.
 gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
-SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2" > exp
+SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1" > exp
 gemini autosomal_dominant  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \
@@ -140,14 +140,14 @@ echo "    auto_dom.t8...\c"
 echo "WARNING: using affected without parents for family 3 for autosomal dominant test. Use strict to prevent this.
 WARNING: using affected without parents for family 2 for autosomal dominant test. Use strict to prevent this.
 gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
-SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2" > exp
+SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1" > exp
 gemini autosomal_dominant  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \
@@ -186,17 +186,17 @@ echo "WARNING: using affected without parents for family 1 for autosomal dominan
 WARNING: using affected without parents for family 3 for autosomal dominant test. Use strict to prevent this.
 WARNING: using affected without parents for family 2 for autosomal dominant test. Use strict to prevent this.
 gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/T,T/T,T/C	1_kid	3
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	3
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	3
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	3
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/C,C/C,C/T	1_kid	3
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	3
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	3
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/C,C/C,C/T	1_kid	3
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	3
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	3
-SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/T,T/T,T/C	1_kid	3
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	3
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	3
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	3" > exp
+SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1" > exp
 gemini autosomal_dominant  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \
@@ -329,11 +329,11 @@ rm obs exp
 ###################################################################
 echo "    auto_dom.t18...\c"
 echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	1
+WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	1
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	1
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	1
-SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	1
-WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	1" > exp
+SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1" > exp
 gemini autosomal_dominant  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --families 3 \

--- a/test/test-auto-rec.sh
+++ b/test/test-auto-rec.sh
@@ -13,11 +13,11 @@ export -f check
 ###################################################################
 echo "    auto_rec.t1...\c"
 echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	2	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/T,C/T,T/T	1_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	C/T,C/T,T/T	2_kid	2
-SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2" > exp
+SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1" > exp
 
 gemini autosomal_recessive  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
@@ -95,11 +95,11 @@ rm obs exp
 echo "    auto_rec.t6...\c"
 echo "WARNING: auto-recessive called on family 1 where no affected has parents
 gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	2	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/T,C/T,T/T	1_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	C/T,C/T,T/T	2_kid	2
-SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2" > exp
+SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1" > exp
 gemini autosomal_recessive  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \
@@ -131,11 +131,11 @@ echo "    auto_rec.t8...\c"
 echo "WARNING: auto-recessive called on family 1 where no affected has parents
 WARNING: auto-recessive called on family 2 where no affected has parents
 gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	2	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/T,C/T,T/T	1_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	C/T,C/T,T/T	2_kid	2
-SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2" > exp
+SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1" > exp
 gemini autosomal_recessive  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \
@@ -169,11 +169,11 @@ echo "WARNING: auto-recessive called on family 1 where no affected has parents
 WARNING: auto-recessive called on family 3 where no affected has parents
 WARNING: auto-recessive called on family 2 where no affected has parents
 gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	2	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/T,C/T,T/T	1_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	C/T,C/T,T/T	2_kid	2
-SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/C,T/C,C/C	2_kid	2" > exp
+SYCE1	chr10	135369531	135369532	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/C,T/C,C/C	3_kid	1" > exp
 gemini autosomal_recessive  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \
@@ -266,8 +266,8 @@ echo "    auto_rec.t16...\c"
 echo "WARNING: no affecteds in family 3
 WARNING: no affecteds in family 2
 gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
-ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	2	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/T,C/T,T/T	1_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	1" > exp
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/C,T/C,C/C	1_kid	1
+ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	2	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	C/T,C/T,T/T	1_kid	1" > exp
 gemini autosomal_recessive  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \

--- a/test/test-dashes.sh
+++ b/test/test-dashes.sh
@@ -1,3 +1,13 @@
+check()
+{
+    if diff $1 $2; then
+        echo ok
+    else
+        echo fail
+        exit 1
+    fi
+}
+export -f check
 
 echo "test-dashes.t01"
 gemini query -q "select chrom,start,end,gt_types.Na-12877 from variants" test.dashes.db > obs
@@ -23,21 +33,21 @@ check obs exp
 
 echo "test-dashes.t02"
 gemini mendel_errors --columns "end,gt_types.Na-12877" test.dashes.db > obs
-echo "end	variant_id	gt_types.Na-12877	family_id	family_members	family_genotypes	samples	family_count	violation	violation_prob
-10671	1	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/C	Na-12877	1	plausible de novo	0.96228
-28494	2	3	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/C,T/T,C/C	Na-12877	1	loss of heterozygosity	0.65973
-28628	3	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	C/C,C/C,C/T	Na-12877	1	plausible de novo	0.98859
-137123	4	0	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,G/G,T/T	Na-12877	1	uniparental disomy	0.88112
-267560	5	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	C/C,C/C,CT/C	Na-12877	1	plausible de novo	0.89649
-537541	6	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,T/T,T/TC	Na-12877	1	plausible de novo	0.72864
-537970	7	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	C/C,C/C,C/T	Na-12877	1	plausible de novo	0.92824
-540712	8	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	CGA/CGA,CGA/CGA,CGA/C	Na-12877	1	plausible de novo	0.81372
-541052	9	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,T/T,T/C	Na-12877	1	plausible de novo	0.75000
-547423	10	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/A	Na-12877	1	plausible de novo	0.74611
-547519	11	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/T	Na-12877	1	plausible de novo	1.00000
-547753	12	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/A	Na-12877	1	plausible de novo	0.75392
-548246	13	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,T/T,T/TA	Na-12877	1	plausible de novo	0.92455
-589086	14	3	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,GAGAA/GAGAA,G/G	Na-12877	1	uniparental disomy	0.94024" > exp
+echo "end	variant_id	gene	gt_types.Na-12877	family_id	family_members	family_genotypes	samples	family_count	violation	violation_prob
+10671	1	DDX11L1	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/C	Na-12877	1	plausible de novo	0.96228
+28494	2	MIR1302-10	3	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/C,T/T,C/C	Na-12877	1	loss of heterozygosity	0.65973
+28628	3	MIR1302-10	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	C/C,C/C,C/T	Na-12877	1	plausible de novo	0.98859
+137123	4	AL627309.1	0	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,G/G,T/T	Na-12877	1	uniparental disomy	0.88112
+267560	5	AP006222.2	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	C/C,C/C,CT/C	Na-12877	1	plausible de novo	0.89649
+537541	6	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,T/T,T/TC	Na-12877	1	plausible de novo	0.72864
+537970	7	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	C/C,C/C,C/T	Na-12877	1	plausible de novo	0.92824
+540712	8	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	CGA/CGA,CGA/CGA,CGA/C	Na-12877	1	plausible de novo	0.81372
+541052	9	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,T/T,T/C	Na-12877	1	plausible de novo	0.75000
+547423	10	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/A	Na-12877	1	plausible de novo	0.74611
+547519	11	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/T	Na-12877	1	plausible de novo	1.00000
+547753	12	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,G/G,G/A	Na-12877	1	plausible de novo	0.75392
+548246	13	RP5-857K21.4	1	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	T/T,T/T,T/TA	Na-12877	1	plausible de novo	0.92455
+589086	14	RP5-857K21.4	3	CEPH1463	Na-12889(Na-12889;unknown;male),Na-12890(Na-12890;unknown;female),Na-12877(Na-12877;unknown;male)	G/G,GAGAA/GAGAA,G/G	Na-12877	1	uniparental disomy	0.94024" >  exp
 check obs exp
 rm obs exp
 

--- a/test/test-de-novo.sh
+++ b/test/test-de-novo.sh
@@ -4,6 +4,7 @@ check()
         echo ok
     else
         echo fail
+		exit 1
     fi
 }
 export -f check
@@ -118,12 +119,12 @@ rm obs exp
 ###################################################################
 echo "    de_novo.t7...\c"
 echo "gene	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/T,T/T,T/C	1_kid	1
 ASAH2C	C	T	missense_variant	MED	2	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	C/C,C/C,C/T	2_kid	2
 ASAH2C	C	T	missense_variant	MED	3	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	C/C,C/C,C/T	3_kid	2
 SYCE1	T	C	missense_variant	MED	5	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/T,T/T,T/C	1_kid	3
 SYCE1	T	C	missense_variant	MED	5	3	3_dad(3_dad;unaffected),3_mom(3_mom;unaffected),3_kid(3_kid;affected)	T/T,T/T,T/C	3_kid	3
-SYCE1	T	C	missense_variant	MED	5	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/T,T/T,T/C	2_kid	3
-WDR37	T	C	stop_lost	HIGH	1	1	1_dad(1_dad;unaffected),1_mom(1_mom;unaffected),1_kid(1_kid;affected)	T/T,T/T,T/C	1_kid	1" > exp
+SYCE1	T	C	missense_variant	MED	5	2	2_dad(2_dad;unaffected),2_mom(2_mom;unaffected),2_kid(2_kid;affected)	T/T,T/T,T/C	2_kid	3" > exp
 gemini de_novo  \
     --columns "gene, ref, alt, impact, impact_severity" \
     --min-kindreds 1 \

--- a/test/test-mendel-error.sh
+++ b/test/test-mendel-error.sh
@@ -13,10 +13,10 @@ export -f check
 echo "    mendel_error.t1..."
 
 gemini mendel_errors --columns "chrom,start,end" test.mendel.db | head -4 > obs
-echo "chrom	start	end	variant_id	family_id	family_members	family_genotypes	samples	family_count	violation	violation_prob
-chr1	10670	10671	1	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	G/G,G/G,G/C	NA12877	1	plausible de novo	0.96228
-chr1	28493	28494	2	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	T/C,T/T,C/C	NA12877	1	loss of heterozygosity	0.65973
-chr1	28627	28628	3	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	C/C,C/C,C/T	NA12877	1	plausible de novo	0.98859" > exp
+echo "chrom	start	end	variant_id	gene	family_id	family_members	family_genotypes	samples	family_count	violation	violation_prob
+chr1	10670	10671	1	None	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	G/G,G/G,G/C	NA12877	1	plausible de novo	0.96228
+chr1	28493	28494	2	None	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	T/C,T/T,C/C	NA12877	1	loss of heterozygosity	0.65973
+chr1	28627	28628	3	None	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	C/C,C/C,C/T	NA12877	1	plausible de novo	0.98859" > exp
 
 check obs exp
 rm exp obs

--- a/test/test-no-gls.sh
+++ b/test/test-no-gls.sh
@@ -4,6 +4,7 @@ check()
     	echo ok
 	else
     	echo fail
+		exit 1
 	fi
 }
 export -f check
@@ -20,10 +21,10 @@ echo " nogls.t2"
 # mendel error uses gl columns to calculate violation prob:
 python drop-gl-columns.py test.mendel.db test.mendelnogls.db
 rm -f obs exp
-echo "chrom	start	end	variant_id	family_id	family_members	family_genotypes	samples	family_count	violation
-chr1	10670	10671	1	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	G/G,G/G,G/C	NA12877	1	plausible de novo
-chr1	28493	28494	2	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	T/C,T/T,C/C	NA12877	1	loss of heterozygosity
-chr1	28627	28628	3	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	C/C,C/C,C/T	NA12877	1	plausible de novo" > exp
+echo "chrom	start	end	variant_id	gene	family_id	family_members	family_genotypes	samples	family_count	violation
+chr1	10670	10671	1	None	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	G/G,G/G,G/C	NA12877	1	plausible de novo
+chr1	28493	28494	2	None	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	T/C,T/T,C/C	NA12877	1	loss of heterozygosity
+chr1	28627	28628	3	None	CEPH1463	NA12889(NA12889;unknown;male),NA12890(NA12890;unknown;female),NA12877(NA12877;unknown;male)	C/C,C/C,C/T	NA12877	1	plausible de novo" > exp
 gemini mendel_errors --columns "chrom,start,end" test.mendelnogls.db | head -4 > obs
 check obs exp
 rm obs exp
@@ -42,14 +43,14 @@ rm obs exp
 
 echo "nogls.auto_dom.t4"
 echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_id	family_id	family_members	family_genotypes	samples	family_count
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
+WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	3	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	C/T,C/C,C/T	3_dad,3_kid	2
 ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	4	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	C/C,C/T,C/T	2_mom,2_kid	2
-SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/T,T/C	3_dad,3_kid	2
-WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	2_dad(2_dad;unaffected),2_mom(2_mom;affected),2_kid(2_kid;affected)	T/T,T/C,T/C	2_mom,2_kid	2
-WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	2	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	T/C,T/C,T/C	3_dad,3_kid	2" > exp
+SPRN	chr10	135336655	135336656	G	A	intron_variant	LOW	5	3	3_dad(3_dad;affected),3_mom(3_mom;unknown),3_kid(3_kid;affected)	G/A,G/G,G/A	3_dad,3_kid	1" > exp
 
 python drop-gl-columns.py test.auto_dom.db test.aa.db
 gemini autosomal_dominant  \


### PR DESCRIPTION
improves speed for some. also require gene for all inheritance tools.
closes #624 and #621