### PR TITLE
remove uncompatibility bug of gemini_install.py

### DIFF
--- a/gemini/scripts/gemini_install.py
+++ b/gemini/scripts/gemini_install.py
@@ -135,11 +135,7 @@ def install_anaconda_python(args, remotes):
 def install_rest(gemini, args):
     """Install biological data and tests used by gemini.
     """
-    if os.path.exists(os.path.join(args.datadir, "data")):
-        annotation_dir = os.path.join(args.datadir, "data")
-    else:
-        annotation_dir = os.path.join(args.datadir, "gemini_data")
-    cmd = [gemini, "--annotation-dir", annotation_dir, "update", "--dataonly"]
+    cmd = [gemini,  "update", "--dataonly"]
     if not args.install_data:
         cmd += ["--nodata"]
     if args.tooldir:


### PR DESCRIPTION
last version of gemini does not support the annotationdir argument anymore in the update function and the install script still pass this argument during the update. This is crashing the instalation through the install script.