### PR TITLE
This is a fix for #676

### DIFF
--- a/docs/content/history.rst
+++ b/docs/content/history.rst
@@ -8,6 +8,11 @@ Release History
 #. Use SQLAlchemy for table definitions in an effort to support different RDBMS backends.
 #. X-linked recessive and dominant tools.
 
+0.18.3
+======
+#. handle rare VEP annotation with '' or "?" as impact
+#. fix handling of multiple values for list/uniq_list in gemini_annotate
+
 0.18.2
 ======
 #. Update the Clinvar annotation file to the February 3, 2016 release.

--- a/gemini/annotations.py
+++ b/gemini/annotations.py
@@ -393,9 +393,10 @@ def annotations_in_vcf(var, anno, parser_type=None, naming="ucsc", region_only=F
             # the mappability uses "." as the alt for all rows. so
             if var_ref == anno_ref and (len(var_alt & anno_alt) >= 1 \
                     or anno_alt == set(".")):
-                matched_hits.append(h)
+                # also need to match on the start coord.
+                if start -1 == coords[1]:
+                    matched_hits.append(h)
         hits = matched_hits
-
     return hits
 
 

--- a/gemini/gemini_annotate.py
+++ b/gemini/gemini_annotate.py
@@ -265,7 +265,12 @@ def annotate_variants_extract(args, conn, col_names, col_types, col_ops, col_idx
                 val = op_funcs[op](hit_list[idx], col_types[idx])
             except ValueError:
                 val = None
-            vals.append(fix_val(val, col_types[idx]))
+            if not 'list' in op:
+                vals.append(fix_val(val, col_types[idx]))
+            else:
+                # already stringed it in list/uniq_list so don't check type
+                vals.append(val)
+
         return vals
 
     return _annotate_variants(args, conn, summarize_hits,


### PR DESCRIPTION
If type was float and op was list, we still checked the type. But the
conversion to a "," delimited list occurs before the type-check.
This simply removes the type check if list or uniq_list is the op.