### PR TITLE
add --gt-filter-required to gemini gene_wise.

### DIFF
--- a/docs/content/history.rst
+++ b/docs/content/history.rst
@@ -2,11 +2,15 @@
 Release History
 #############################
 
-0.19.0 (future)
+0.20.0 (future)
 ===============
 #. Use vcfanno for faster, more generalized variant annotation and database creation.
+
+0.19.0 (future)
+===============
 #. Use SQLAlchemy for table definitions in an effort to support different RDBMS backends.
 #. X-linked recessive and dominant tools.
+#. x-linked inheritance models (TODO: expose in gemini and bump inheritance req)
 
 0.18.3
 ======
@@ -14,7 +18,7 @@ Release History
 #. fix handling of multiple values for list/uniq_list in gemini_annotate
 #. handle snpEff with unknown impact (TODO: bump geneimpacts req to 0.1.0)
 #. fix builtin browser and add support for puzzle browser
-#. x-linked inheritance models (TODO: expose in gemini and bump inheritance req)
+#. add --gt-filter-required to gemini gene_wise tool that must pass for each variant.
 
 0.18.2
 ======

--- a/docs/content/tools.rst
+++ b/docs/content/tools.rst
@@ -691,6 +691,7 @@ With this tool, multiple `--gt-filter` s can be specified. Each filter can
 be any valid filter; often, it will make sense to have 1 filter for each
 family. For example, given this pedigree:
 
+
 .. image:: ../images/gene_wise_example.png
 
 Where only the orange samples are sequenced, we could devise a query::
@@ -731,6 +732,27 @@ As with the other tools, this tool orders by chromosome and gene and it applies 
  + The `variant_filters` column shows which filters were passed by the variant.
  + The `n_gene_variants` column shows how many variants in the gene are being reported.
  + The `gene_filter` column shows which filters in the gene passed by any variant.
+
+Multiple `--gt-filter-required` filters can also be specified. Each filter added
+to this argument is required to pass for each variant and it does not contribute
+to the `--min-filters` argument. This can be used with, or instead of `--gt-filter`
+E.g.
+
+::
+
+    gemini gene_wise  \
+        --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
+        --gt-filter-required "((gt_depths).(*).(>10).(all))" \
+        --gt-filter "gt_types.fam1_kid == HET and gt_types.fam1_mom == HOM_REF and gt_types.fam1_dad == HOM_REF" \
+        --gt-filter "gt_types.fam2_kid == HET" \
+        --gt-filter "gt_types.fam3_kid == HET" \
+        --min-filters 2 \
+        test.db 
+
+
+will required that all samples meet the minimum depth filter and then keep
+the subset of those that meet 2 out of the 3 `--gt-filters`.
+
 
 ===========================================================================
 ``pathways``: Map genes and variants to KEGG pathways.

--- a/master-test.sh
+++ b/master-test.sh
@@ -22,17 +22,18 @@ cd test
 #rm ./*.db
 
 # setup the testing databases from the testing VCF files
+set -e
 bash data-setup.sh
 
-bash test-vep-extra.sh
+bash test-vep-extra.sh || exit
 
-bash test-vcf-output.sh
+bash test-vcf-output.sh || exit
 
-bash test-mendel-error.sh
+bash test-mendel-error.sh || exit
 
-bash test-genotype-likelihoods.sh
+bash test-genotype-likelihoods.sh || exit
 
-bash test-t-all.sh
+bash test-t-all.sh || exit
 
 # Test gemini region
 bash test-region.sh
@@ -151,6 +152,8 @@ bash test-eff.sh
 
 bash test-geno2mp.sh
 
+bash test-genewise.sh
+
 # cleanup
-rm ./*.db
+#rm ./*.db
 rm -Rf *.gts

--- a/test/test-genewise.sh
+++ b/test/test-genewise.sh
@@ -23,9 +23,9 @@ PEDIGREE
 echo "genewise.t1"
 
 echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_filters	n_gene_variants	gene_filters
-ASAH2C	chr10	48003991	48003992	C	T	non_syn_coding	MED	1	2	1
-ASAH2C	chr10	48004991	48004992	C	T	non_syn_coding	MED	1	2	1
-WDR37	chr10	1142207	1142208	T	C	stop_loss	HIGH	1	1	1" > exp
+ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	1	2	1
+ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	1	2	1
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	1	1" > exp
 
 gemini gene_wise  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
@@ -46,9 +46,9 @@ rm obs exp
 
 echo "genewise.t3"
 echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_filters	n_gene_variants	gene_filters
-ASAH2C	chr10	48003991	48003992	C	T	non_syn_coding	MED	1,2	2	1,2
-ASAH2C	chr10	48004991	48004992	C	T	non_syn_coding	MED	1,2	2	1,2
-WDR37	chr10	1142207	1142208	T	C	stop_loss	HIGH	1,2	1	1,2" > exp
+ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	1,2	2	1,2
+ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	1,2	2	1,2
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1,2	1	1,2" > exp
 gemini gene_wise  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
 	--gt-filter "(gt_types.2_dad == HOM_REF and gt_types.2_kid == HET and gt_types.2_mom == HET)" \
@@ -59,12 +59,39 @@ check obs exp
 
 echo "genewise.t4"
 echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_filters	n_gene_variants	gene_filters
-ASAH2C	chr10	48003991	48003992	C	T	non_syn_coding	MED	1	2	1
-ASAH2C	chr10	48004991	48004992	C	T	non_syn_coding	MED	1	2	1
-WDR37	chr10	1142207	1142208	T	C	stop_loss	HIGH	1	2	1
-WDR37	chr10	1142208	1142209	T	C	stop_loss	HIGH	1	2	1" > exp
+ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	1	2	1
+ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	1	2	1
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	1	2	1
+WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	1	2	1" > exp
 gemini gene_wise  \
     --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
+	--gt-filter  "((gt_types).(phenotype==1).(==HOM_ALT).(none))" \
+	--min-filters 1 \
+    test.auto_dom.db  > obs
+check obs exp
+
+
+echo "genewise.t5"
+echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_filters	n_gene_variants	gene_filters
+ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	required[1]	2	
+ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	required[1]	2	
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	required[1]	2	
+WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	required[1]	2	" > exp
+gemini gene_wise  \
+    --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
+	--gt-filter-required "((gt_types).(phenotype==1).(==HOM_ALT).(none))" \
+    test.auto_dom.db  > obs
+check obs exp
+
+echo "genewise.t6"
+echo "gene	chrom	start	end	ref	alt	impact	impact_severity	variant_filters	n_gene_variants	gene_filters
+ASAH2C	chr10	48003991	48003992	C	T	missense_variant	MED	required[1],1	2	1
+ASAH2C	chr10	48004991	48004992	C	T	missense_variant	MED	required[1],1	2	1
+WDR37	chr10	1142207	1142208	T	C	stop_lost	HIGH	required[1],1	2	1
+WDR37	chr10	1142208	1142209	T	C	stop_lost	HIGH	required[1],1	2	1" > exp
+gemini gene_wise  \
+    --columns "gene, chrom, start, end, ref, alt, impact, impact_severity" \
+	--gt-filter-required "((gt_types).(phenotype==1).(==HOM_ALT).(none))" \
 	--gt-filter  "((gt_types).(phenotype==1).(==HOM_ALT).(none))" \
 	--min-filters 1 \
     test.auto_dom.db  > obs


### PR DESCRIPTION
This closes #529 and does some of #576. Users can specify as many
required filters as needed; all of them must pass.

This can be used in concert with, or instead of --gt-filter.