### PR TITLE
make sure that commands are output in order.

### DIFF
--- a/gemini/gemini_main.py
+++ b/gemini/gemini_main.py
@@ -1203,6 +1203,11 @@ def main():
     #######################################################
     # parse the args and call the selected function
     #######################################################
+    import operator
+    subparsers._choices_actions.sort(key=operator.attrgetter('dest'))
+    for k in sorted(subparsers.choices):
+        subparsers.choices[k] = subparsers.choices.pop(k)
+
     args = parser.parse_args()
 
     # make sure database is found if provided


### PR DESCRIPTION
output now looks like:
```
gemini: error: argument command: invalid choice: 'cc' (choose from 'actionable_mutations', 'amend', 'annotate', 'autosomal_dominant', 'autosomal_recessive', 'bcolz_index', 'browser', 'burden', 'comp_hets', 'db_info', 'de_novo', 'dump', 'examples', 'fusions', 'gene_wise', 'interactions', 'load', 'load_chunk', 'lof_interactions', 'lof_sieve', 'mendel_errors', 'merge_chunks', 'pathways', 'qc', 'query', 'region', 'roh', 'set_somatic', 'stats', 'update', 'windower', 'x_linked_de_novo', 'x_linked_dominant', 'x_linked_recessive')
```

previously, the sub-commands were in order they were added to the parser which wasn't easy for a human to parse.