### PR TITLE
don't send stderr to check_call explicitly.

### DIFF
--- a/docs/content/history.rst
+++ b/docs/content/history.rst
@@ -10,6 +10,7 @@ Release History
 ======
 #. Initial support for python 3.
 #. Support annotating with bcftools BCSQ (http://biorxiv.org/content/early/2016/12/01/090811) in addition to VEP and SnpEff.
+#. Fix bug that resulted in the message: `UnsupportedOperation: IOStream has no fileno.` when loading. (Thanks Andrew O. and Ryan R.)
 
 0.19.1
 ======

--- a/gemini/gemini_load.py
+++ b/gemini/gemini_load.py
@@ -337,8 +337,9 @@ def load_chunk(chunk_step, kwargs):
     chunk_num, chunk = chunk_step
     start, stop = chunk
     args = combine_dicts(locals(), kwargs)
+    args["vcf"] = os.path.abspath(args["vcf"])
     gemini_load = gemini_pipe_load_cmd().format(**args)
-    subprocess.check_call(gemini_load, shell=True, stderr=sys.stderr)
+    subprocess.check_call(gemini_load, shell=True)
     chunk_db = kwargs["chunk_dir"] + args["vcf"] + ".chunk" + str(chunk_num) + ".db"
     return chunk_db
 

--- a/gemini/gemini_main.py
+++ b/gemini/gemini_main.py
@@ -195,6 +195,8 @@ def main():
                          default=False)
     def load_fn(parser, args):
         from gemini import gemini_load
+        if args.vcf != "-":
+            args.vcf = os.path.abspath(args.vcf)
         gemini_load.load(parser, args)
 
     parser_load.set_defaults(func=load_fn)
@@ -296,6 +298,8 @@ def main():
 
     def loadchunk_fn(parser, args):
         from gemini import gemini_load_chunk
+        if args.vcf != "-":
+            args.vcf = os.path.abspath(args.vcf)
         gemini_load_chunk.load(parser, args)
     parser_loadchunk.set_defaults(func=loadchunk_fn)
 


### PR DESCRIPTION
this avoids errors with ipython which gave the message:
"UnsupportedOperation: IOStream has no fileno."