### PR TITLE
Fix requirements for version 0.19.1

### DIFF
--- a/versioning/0.19.1/requirements_conda.txt
+++ b/versioning/0.19.1/requirements_conda.txt
@@ -1,7 +1,7 @@
 # This file may be used to create an environment using:
 # $ conda create --name <env> --file <this file>
 # platform: linux-64
-gemini=0.19.0=py27_2
+gemini=0.19.1=py27_2
 bx-python=0.7.3=py27_0
 cyvcf2>=0.4.2
 conda=3.5.5=py27_0


### PR DESCRIPTION
@arq5x I'm encountering this error when attempting to install version 0.19.1 based on your installation info here: http://gemini.readthedocs.io/en/latest/content/installation.html
```
$ python gemini_install.py --gemini-version 0.19.1 /home/greg/gemini/ /home/greg/gemini/share/gemini/
<some logging eliminated...>
installation finished.
Installing base gemini package...
/home/greg/gemini/share/gemini/anaconda/bin/conda install --yes -c bioconda --file _conda-requirements-0.19.1.txt
Fetching package metadata .................

PackageNotFoundError: Package not found: '' Package missing in current linux-64 channels: 
  - gemini 0.19.0 py27_2

You can search for packages on anaconda.org with

    anaconda search -t conda gemini

Traceback (most recent call last):
  File "gemini_install.py", line 191, in <module>
    main(parser.parse_args())
  File "gemini_install.py", line 83, in main
    gemini = install_conda_pkgs(anaconda, remotes, args)
  File "gemini_install.py", line 105, in install_conda_pkgs
    subprocess.check_call([anaconda["conda"], "install", "--yes"] + channels + pkgs)
  File "/usr/lib64/python2.7/subprocess.py", line 186, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['/home/greg/gemini/share/gemini/anaconda/bin/conda', 'install', '--yes', '-c', 'bioconda', '--file', '_conda-requirements-0.19.1.txt']' returned non-zero exit status 1
```
I assume the issues is caused by having version 0.19.0 in the requirement.txt file, which this PR changes to be 0.19.1.  If this is not the problem, please let me know and I will close this PR.

Thanks!